### PR TITLE
Fix issues with pod labeling

### DIFF
--- a/pkg/mysqlcluster/cluster.go
+++ b/pkg/mysqlcluster/cluster.go
@@ -170,6 +170,9 @@ func (f *cFactory) Sync(ctx context.Context) error {
 		return fmt.Errorf("cluster sync ready endpoints: %s", err)
 	}
 
+	if err := f.updatePodLabels(); err != nil {
+		return fmt.Errorf("cluster sync pod labeling: %s", err)
+	}
 	return nil
 }
 

--- a/pkg/mysqlcluster/endpoints.go
+++ b/pkg/mysqlcluster/endpoints.go
@@ -30,9 +30,6 @@ const (
 
 func (f *cFactory) updateMasterServiceEndpoints() error {
 	masterHost := f.getMasterHost()
-	if err := f.updatePodLabels(masterHost); err != nil {
-		return err
-	}
 
 	return f.addNodesToService(f.cluster.GetNameForResource(api.MasterService), masterHost)
 }

--- a/pkg/mysqlcluster/pods.go
+++ b/pkg/mysqlcluster/pods.go
@@ -45,7 +45,8 @@ func (f *cFactory) updatePodLabels() error {
 			desiredVal = "master"
 		}
 
-		glog.Infof("Inspecting pod: %s, label: %s, desired: %s", pod.Name, val, desiredVal)
+		glog.V(2).Infof("Inspecting pod: %s, label: %s, desired: %s", pod.Name, val, desiredVal)
+
 		if !exists || val != desiredVal {
 			labels["role"] = desiredVal
 			glog.Infof("Updating labels for Pod: %s", pod.Name)

--- a/pkg/mysqlcluster/utils.go
+++ b/pkg/mysqlcluster/utils.go
@@ -107,12 +107,12 @@ func (f *cFactory) addNodesToService(serviceName string, hosts ...string) error 
 	for _, host := range hosts {
 		pod, err := getPodForHostname(f.client, f.namespace, f.getLabels(map[string]string{}), host)
 		if err != nil {
-			glog.Errorf("Failed to set master service endpoints: %s", err)
+			glog.Errorf("Failed to set %s service endpoints: %s", serviceName, err)
 			continue
 		}
 
 		if len(pod.Status.PodIP) == 0 {
-			glog.Errorf("Failed to set master service endpoints, ip for pod %s not set %s", pod.Name, err)
+			glog.Errorf("Failed to set %s service endpoints, ip for pod %s not set %s", serviceName, pod.Name, err)
 			continue
 		}
 		pods = append(pods, pod)
@@ -162,8 +162,7 @@ func (f *cFactory) addNodesToService(serviceName string, hosts ...string) error 
 			return in
 		})
 
-	glog.Infof("Endpoints for service '%s' were %s.",
-		f.cluster.GetNameForResource(api.MasterService), getStatusFromKVerb(act))
+	glog.Infof("Endpoints for service '%s' were %s.", serviceName, getStatusFromKVerb(act))
 
 	return err
 }


### PR DESCRIPTION
Pod labeling does not reliably work. Sometimes, the endpoint sync finishes successfully, without pod labeling going through. This change separates out pod labeling call from endpoint sync functions. Pod labeling returns errors so that sync calls again if it did not finish.
Also fixed an issue with logging -- endpoint function now logs the service name instead of always assuming master service.