### PR TITLE
Fix a bug in Reconciliation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ bin/
 hack/docker/mysql-helper/mysql-helper
 hack/docker/mysql-operator/mysql-operator
 **/charts/*.tgz
+
+# ignore vscode
+.vscode


### PR DESCRIPTION
fixes: https://github.com/presslabs/mysql-operator/issues/69
When a cluster is deleted and  re-created (with the same name), the orc reconciliation does not work. This is because an internal map in operator is not updated. This change removes the deleted cluster from the map as well. It also fixes a few nits in the code and adds gitignore entries for folks using vscode.
