### PR TITLE
Add volume cleanup option

### DIFF
--- a/cmd/mysql-operator/app/controller.go
+++ b/cmd/mysql-operator/app/controller.go
@@ -51,6 +51,8 @@ import (
 	// Register all available controllers
 	_ "github.com/presslabs/mysql-operator/pkg/controller/backupscontroller"
 	_ "github.com/presslabs/mysql-operator/pkg/controller/clustercontroller"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 const controllerAgentName = "mysql-controller"

--- a/deploy/mysqlclusters.yaml
+++ b/deploy/mysqlclusters.yaml
@@ -127,6 +127,15 @@ spec:
                   items:
                     type: string
                   type: array
+                cleanupGracePeriod:
+                  description: CleanupGracePeriod specifies wait time in seconds before
+                    cleaning up persistent volume claims of a pod. Cleanup ensures
+                    that (1) space is returned to the storage layer after a cluster
+                    is deleted/scaled. It also ensures that mysql pods start replication
+                    with a clean volume. Default value of 0 means volume claims are
+                    not touched.
+                  format: int32
+                  type: integer
                 resources: {}
                 selector:
                   description: A label selector is a label query over a set of resources.

--- a/hack/charts/mysql-operator/templates/rbac.yaml
+++ b/hack/charts/mysql-operator/templates/rbac.yaml
@@ -21,6 +21,7 @@ rules:
       - services
       - pods
       - jobs
+      - persistentvolumeclaims
     verbs: ["*"]
   - apiGroups: ["apps"]
     resources:

--- a/pkg/apis/mysql/v1alpha1/types.go
+++ b/pkg/apis/mysql/v1alpha1/types.go
@@ -163,6 +163,13 @@ type PodSpec struct {
 
 type VolumeSpec struct {
 	core.PersistentVolumeClaimSpec `json:",inline"`
+	// CleanupGracePeriod specifies wait time in seconds before cleaning up
+	// persistent volume claims of a pod. Cleanup ensures that (1) space is
+	// returned to the storage layer after a cluster is deleted/scaled.
+	// It also ensures that mysql pods start replication with a clean volume.
+	// Default value of 0 means volume claims are not touched.
+	// + optional
+	CleanupGracePeriod int `json:"cleanupGracePeriod,omitempty"`
 }
 
 // QueryLimits represents the pt-kill parameters, more info can be found

--- a/pkg/controller/clustercontroller/cleanup.go
+++ b/pkg/controller/clustercontroller/cleanup.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2018 Platform9, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustercontroller
+
+import (
+	"k8s.io/apimachinery/pkg/util/runtime"
+
+	"github.com/golang/glog"
+	api "github.com/presslabs/mysql-operator/pkg/apis/mysql/v1alpha1"
+	controllerpkg "github.com/presslabs/mysql-operator/pkg/controller"
+	clusterpkg "github.com/presslabs/mysql-operator/pkg/mysqlcluster"
+)
+
+func (c *Controller) registerClusterCleanup(cluster *api.MysqlCluster) {
+	key, err := controllerpkg.KeyFunc(cluster)
+
+	if err != nil {
+		runtime.HandleError(err)
+		return
+	}
+
+	_, loaded := c.clustersCleanup.LoadOrStore(key, *cluster)
+
+	if !loaded {
+		glog.V(2).Infof("Registered cluster '%s' for cleanup.", key)
+	}
+}
+
+func (c *Controller) cleanupCluster(key string) {
+	val, exists := c.clustersCleanup.Load(key)
+	if !exists {
+		glog.V(2).Infof("Cluster '%s' parameters not found, skipping cleanup", key)
+		return
+	}
+
+	if cluster, ok := val.(api.MysqlCluster); ok {
+		clusterpkg.CleanupVolumeClaims(&c.k8client, &cluster)
+		c.clustersCleanup.Delete(key)
+	} else {
+		glog.Errorf("Cluster '%s' cleanup parameters invalid, skipping cleanup", key)
+	}
+}

--- a/pkg/controller/clustercontroller/sync.go
+++ b/pkg/controller/clustercontroller/sync.go
@@ -70,6 +70,7 @@ func (c *Controller) Sync(ctx context.Context, cluster *api.MysqlCluster) error 
 
 	c.registerClusterInReconciliation(cluster)
 	c.registerClusterInBackupCron(cluster)
+	c.registerClusterCleanup(cluster)
 
 	return nil
 }

--- a/pkg/mysqlcluster/utils.go
+++ b/pkg/mysqlcluster/utils.go
@@ -198,3 +198,17 @@ func getRecoveryTextMsg(acks []orc.TopologyRecovery) string {
 
 	return fmt.Sprintf("[%s]", text)
 }
+
+func getVolumeClaimsForCluster(client *kubernetes.Interface, ns string, lbls labels.Set, clusterName string) (*core.PersistentVolumeClaimList, error) {
+	selector := labels.SelectorFromSet(lbls)
+
+	claimList, err := (*client).CoreV1().PersistentVolumeClaims(ns).List(metav1.ListOptions{
+		LabelSelector: selector.String(),
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("listing volume claims: %s", err)
+	}
+
+	return claimList, nil
+}

--- a/pkg/mysqlcluster/volumes.go
+++ b/pkg/mysqlcluster/volumes.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2018 Platform9, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mysqlcluster
+
+import (
+	"time"
+
+	"github.com/golang/glog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	api "github.com/presslabs/mysql-operator/pkg/apis/mysql/v1alpha1"
+)
+
+// CleanupVolumeClaims deletes persistent volume claims of mysql cluster if needed
+func CleanupVolumeClaims(client *kubernetes.Interface, cluster *api.MysqlCluster) error {
+	cleanupGracePeriod := cluster.Spec.VolumeSpec.CleanupGracePeriod
+	if cleanupGracePeriod <= 0 {
+		return nil
+	}
+
+	timer := time.NewTimer(time.Duration(cleanupGracePeriod) * time.Second)
+
+	go func(client *kubernetes.Interface, cluster *api.MysqlCluster) {
+		<-timer.C
+		name := cluster.Name
+		glog.V(2).Info("Cleaning up volume claims for cluster: %s", name)
+
+		// Get all volume claims in the cluster
+		claimList, err := getVolumeClaimsForCluster(client, cluster.Namespace, cluster.GetLabels(), name)
+
+		if err != nil {
+			glog.Errorf("Error deleting volume claims for cluster %s: %s", name, err)
+			return
+		}
+
+		api := (*client).CoreV1()
+		for _, claim := range claimList.Items {
+			api.PersistentVolumeClaims(cluster.Namespace).Delete(claim.Name, &metav1.DeleteOptions{})
+		}
+
+		glog.V(2).Info("Cleaned up all volume claims for cluster: %s", name)
+
+	}(client, cluster)
+
+	return nil
+}

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -812,6 +812,13 @@ func schema_pkg_apis_mysql_v1alpha1_VolumeSpec(ref common.ReferenceCallback) com
 							Format:      "",
 						},
 					},
+					"cleanupGracePeriod": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CleanupGracePeriod specifies wait time in seconds before cleaning up persistent volume claims of a pod. Cleanup ensures that (1) space is returned to the storage layer after a cluster is deleted/scaled. It also ensures that mysql pods start replication with a clean volume. Default value of 0 means volume claims are not touched.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
(Partially) addresses issue #73 
This change adds a new option "cleanupGracePeriod" to mysql cluster spec. If specified, the operator deletes persistent volume claims when a cluster is deleted.
As per the discussion in #73, cluster scale events should trigger cleanup, but we need to agree upon if the (1) scale down triggers cleanup (2) if so, add a pod watcher to cleanup corresponding pvc.