### PR TITLE
Add owner reference for PVC

### DIFF
--- a/pkg/mysqlcluster/cluster.go
+++ b/pkg/mysqlcluster/cluster.go
@@ -81,7 +81,7 @@ const (
 	statusUpToDate = "up-to-date"
 	statusCreated  = "created"
 	statusUpdated  = "updated"
-	statusFailed   = "faild"
+	statusFailed   = "failed"
 	statusOk       = "ok"
 	statusSkip     = "skip"
 )

--- a/pkg/mysqlcluster/statefullset.go
+++ b/pkg/mysqlcluster/statefullset.go
@@ -459,12 +459,21 @@ func (f *cFactory) ensureVolumes(in []core.Volume) []core.Volume {
 }
 
 func (f *cFactory) ensureVolumeClaimTemplates(in []core.PersistentVolumeClaim) []core.PersistentVolumeClaim {
+	initPvc := false
 	if len(in) == 0 {
 		in = make([]core.PersistentVolumeClaim, 1)
+		initPvc = true
 	}
 	data := in[0]
 
 	data.Name = dataVolumeName
+
+	if initPvc {
+		// This can be set only when creating new PVC. It ensures that PVC can be
+		// terminated after deleting parent MySQL cluster
+		data.ObjectMeta.OwnerReferences = f.getOwnerReferences()
+	}
+
 	data.Spec = f.cluster.Spec.VolumeSpec.PersistentVolumeClaimSpec
 
 	in[0] = data


### PR DESCRIPTION
This ensures that PVCs get deleted upon deletion of mysql cluster. The PVC description now looks like this --
`ownerReferences:
  - apiVersion: mysql.presslabs.org/v1alpha1
    controller: true
    kind: MysqlCluster
    name: foo
    uid: 1c518200-8c64-11e8-9952-42010a800107`