### PR TITLE
Fix namespace command line arg behavior

### DIFF
--- a/cmd/mysql-operator/app/controller.go
+++ b/cmd/mysql-operator/app/controller.go
@@ -68,9 +68,6 @@ mysql-operator is a Kubernetes addon to automate the deployment, scaling and
 management of multiple mysql clusters.`,
 		// TODO: Refactor this function from this package
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := o.Validate(); err != nil {
-				glog.Fatalf("error validating options: %s", err.Error())
-			}
 			if err := gOpt.Validate(); err != nil {
 				glog.Fatalf("error validating mysql controller options: %s", err.Error())
 			}

--- a/cmd/mysql-operator/app/options/options.go
+++ b/cmd/mysql-operator/app/options/options.go
@@ -17,11 +17,9 @@ limitations under the License.
 package options
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/spf13/pflag"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 type MysqlControllerOptions struct {
@@ -43,7 +41,7 @@ type MysqlControllerOptions struct {
 
 const (
 	defaultAPIServerHost = ""
-	defaultNamespace     = "default"
+	defaultNamespace     = ""
 
 	defaultLeaderElect                 = true
 	defaultLeaderElectionNamespace     = "kube-system"
@@ -74,8 +72,8 @@ func (s *MysqlControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		"Optional apiserver host address to connect to. If not specified, autoconfiguration "+
 		"will be attempted.")
 	fs.StringVar(&s.Namespace, "namespace", defaultNamespace, ""+
-		"Namespace to monitor resources within. If not specified, default "+
-		"namespace will be watched")
+		"Namespace to monitor resources within. If not specified, all "+
+		"namespaces will be watched")
 
 	fs.BoolVar(&s.LeaderElect, "leader-elect", true, ""+
 		"If true, mysql-controller will perform leader election between instances "+
@@ -105,12 +103,4 @@ func (s *MysqlControllerOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.BoolVar(&s.InstallCRDs, "install-crds", defaultInstallCRDs, "Whether or not to install CRDs.")
 
-}
-
-func (o *MysqlControllerOptions) Validate() error {
-	var errs []error
-	if len(o.Namespace) == 0 {
-		errs = append(errs, fmt.Errorf("no namespace specified"))
-	}
-	return utilerrors.NewAggregate(errs)
 }


### PR DESCRIPTION
Fixes #87 
This change sets the default namespace value as empty string. That way, if namespace is not specified , the operator watches mysql cluster creations across all namespaces.
If specified, it limits the scope to desired namespace.