### PR TITLE
Expose S3_PROVIDER and S3_ENTRYPOINT rconf settings to be able to use backup to S3 with other providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Status:
 
 ## Backups
 
-Backups are stored on object storage services like S3 or google cloud storage. In order to be able to store backup, the secret defined under `backupBucketSecretName` must the credentias to store those backups.
+Backups are stored on object storage services like S3 or google cloud storage. In order to be able to store backup, the secret defined under `backupBucketSecretName` must the credentials to store those backups. The backups are uploaded using [Rclone](https://rclone.org/). The contents of the secret are used to generate an rclone.conf in [hack/docker/mysql-helper/docker-entrypoint.sh](hack/docker/mysql-helper/docker-entrypoint.sh).
 
 ### Setup backup to S3
 
@@ -105,6 +105,12 @@ data:
   # AWS_REGION: us-east1
   # Optional, specify the storage class
   # AWS_STORAGE_CLASS: standard
+  # Optional, canned ACL to use
+  # AWS_ACL:
+  # Optional, the S3 provider to use (default: AWS)
+  # S3_PROVIDER: AWS
+  # Optional, the S3 endpoint to use (for when you use a different S3_PROVIDER)
+  # S3_ENDPOINT:
 ```
 
 ### Setup backup to gcloud

--- a/examples/example-backup-secret.yaml
+++ b/examples/example-backup-secret.yaml
@@ -8,6 +8,8 @@ data:
     # AWS_SECRET_KEY: ?
     # AWS_REGION: us-east-1
     # AWS_ACL: ?
+    # S3_PROVIDER: AWS
+    # S3_ENDPOINT: ?
 
     # GCS_SERVICE_ACCOUNT_JSON_KEY: ?
     # GCS_PROJECT_ID: ?
@@ -19,3 +21,4 @@ data:
     # HTTP_URL: ?
 
 # for more details check docker entrypoint: hack/docker/mysql-helper/docker-entrypoint.sh
+# and rclone documentation: https://rclone.org/

--- a/hack/docker/mysql-helper/docker-entrypoint.sh
+++ b/hack/docker/mysql-helper/docker-entrypoint.sh
@@ -6,9 +6,11 @@ cat <<EOF > /etc/rclone.conf
 [s3]
 type = s3
 env_auth = false
+provider = ${S3_PROVIDER:-"AWS"}
 access_key_id = ${AWS_ACCESS_KEY_ID}
 secret_access_key = ${AWS_SECRET_KEY}
 region = ${AWS_REGION:-"us-east-1"}
+endpoint = ${S3_ENDPOINT}
 acl = ${AWS_ACL}
 storage_class = ${AWS_STORAGE_CLASS}
 


### PR DESCRIPTION
This PR is to make the S3 backups usable/compatible with S3 compatible providers other than AWS.

- add S3_PROVIDER and S3_ENDPOINT settings to the rclone.conf generator in the entrypoint for the mysql-helper
- add docs for these settings in README and backup secret example
- fix typo in README
- add AWS_ACL to the structure given in the README under 'setup backup to S3'"