### PR TITLE
Cleanup deleted mysql cluster from orchestrator

### DIFF
--- a/pkg/apis/mysql/v1alpha1/cluster.go
+++ b/pkg/apis/mysql/v1alpha1/cluster.go
@@ -145,11 +145,6 @@ func (c *ClusterSpec) GetMetricsExporterImage() string {
 	return opt.MetricsExporterImage
 }
 
-// GetOrcUri return the orchestrator uri
-func (c *ClusterSpec) GetOrcUri() string {
-	return opt.OrchestratorUri
-}
-
 // GetMysqlImage returns mysql image, composed from oprions and  Spec.MysqlVersion
 func (c *ClusterSpec) GetMysqlImage() string {
 	return opt.MysqlImage + ":" + c.MysqlVersion

--- a/pkg/controller/clustercontroller/controller.go
+++ b/pkg/controller/clustercontroller/controller.go
@@ -254,7 +254,7 @@ func (c *Controller) workerReconcile(stopCh <-chan struct{}) {
 				return nil
 			}
 
-			if value, exists := c.clustersSync.Load(key); exists && !value.(bool) {
+			if _, exists := c.clustersSync.Load(key); !exists {
 				// key is removed from map, don't execute reconciliation
 				return nil
 			}

--- a/pkg/mysqlcluster/statefullset.go
+++ b/pkg/mysqlcluster/statefullset.go
@@ -173,7 +173,7 @@ func (f *cFactory) getEnvFor(name string) (env []core.EnvVar) {
 	})
 	env = append(env, core.EnvVar{
 		Name:  "ORCHESTRATOR_URI",
-		Value: f.cluster.Spec.GetOrcUri(),
+		Value: f.opt.OrchestratorUri,
 	})
 
 	if len(f.cluster.Spec.InitBucketUri) > 0 && name == containerCloneName {

--- a/pkg/util/orchestrator/fake/client.go
+++ b/pkg/util/orchestrator/fake/client.go
@@ -160,6 +160,10 @@ func (o *FakeOrc) Cluster(cluster string) ([]Instance, error) {
 	return Insts, nil
 }
 
+func (o *FakeOrc) ForgetCluster(cluster string) error {
+	return nil
+}
+
 func (o *FakeOrc) AuditRecovery(cluster string) ([]TopologyRecovery, error) {
 	recoveries, ok := o.Recoveries[cluster]
 	if !ok {

--- a/pkg/util/orchestrator/orchestrator.go
+++ b/pkg/util/orchestrator/orchestrator.go
@@ -28,6 +28,8 @@ type Interface interface {
 
 	Cluster(cluster string) ([]Instance, error)
 
+	ForgetCluster(cluster string) error
+
 	AuditRecovery(cluster string) ([]TopologyRecovery, error)
 	AckRecovery(id int64, commnet string) error
 
@@ -82,6 +84,13 @@ func (o *orchestrator) Cluster(cluster string) ([]Instance, error) {
 	}
 
 	return insts, nil
+}
+
+func (o *orchestrator) ForgetCluster(cluster string) error {
+	if err := o.makeGetAPIRequest(fmt.Sprintf("forget-cluster/%s", cluster), nil); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (o *orchestrator) AuditRecovery(cluster string) ([]TopologyRecovery, error) {


### PR DESCRIPTION
This change fixes issue #112. The deleted clusters hang on in orchestrator for a while (appearing as failed). This change fixes it by calling orchestrator forget cluster api when a cluster is being removed from reconcile queue.