### PR TITLE
Add lazy cleanup of PVC on Mysql cluster deletion

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -753,6 +753,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "30724a602072b4fa69c5bbb3e9fdaf2b53865c11025949fff7978434d499aa2a"
+  inputs-digest = "001df6d6a98c2e7a75a1f317462743c75e65ee9032c75e28183c6f708054006b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/controller/clustercontroller/cleanups.go
+++ b/pkg/controller/clustercontroller/cleanups.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2018 Platform9, Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustercontroller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/glog"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// CleanupRetryError Indicates retry on error
+type CleanupRetryError struct {
+	msg string
+}
+
+func (e *CleanupRetryError) Error() string {
+	return e.msg
+}
+
+// Cleanup deletes any orphaned objects created by Mysql cluster
+func (c *Controller) Cleanup(ctx context.Context, name string, namespace string) error {
+
+	glog.Infof("Cleaning up cluster: %s", name)
+
+	client := c.k8client
+
+	lbs := map[string]string{
+		"app":           "mysql-operator",
+		"mysql_cluster": name}
+
+	selector := labels.SelectorFromSet(lbs)
+	listOpt := metav1.ListOptions{
+		LabelSelector: selector.String()}
+
+	podList, err := client.CoreV1().Pods(namespace).List(listOpt)
+
+	if err != nil {
+		return fmt.Errorf("listing pods: %s", err)
+	}
+
+	if len(podList.Items) > 0 {
+		msg := fmt.Sprintf("Pods still terminating for cluster: %s", name)
+		glog.V(2).Infof(msg)
+		return &CleanupRetryError{msg: msg}
+	}
+
+	pvcList, err := client.CoreV1().PersistentVolumeClaims(namespace).List(listOpt)
+
+	if err != nil {
+		return fmt.Errorf("listing pvcs: %s", err)
+	}
+
+	for _, pvc := range pvcList.Items {
+		err := client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(pvc.Name, nil)
+		if err != nil {
+			glog.Warningf("Error deleting pvc: %s", err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/mysqlcluster/statefullset.go
+++ b/pkg/mysqlcluster/statefullset.go
@@ -467,19 +467,23 @@ func (f *cFactory) ensureVolumes(in []core.Volume) []core.Volume {
 }
 
 func (f *cFactory) ensureVolumeClaimTemplates(in []core.PersistentVolumeClaim) []core.PersistentVolumeClaim {
-	initPvc := false
+	init := false
 	if len(in) == 0 {
 		in = make([]core.PersistentVolumeClaim, 1)
-		initPvc = true
+		init = true
 	}
+
 	data := in[0]
 
 	data.Name = dataVolumeName
 
-	if initPvc {
-		// This can be set only when creating new PVC. It ensures that PVC can be
-		// terminated after deleting parent MySQL cluster
-		data.ObjectMeta.OwnerReferences = f.getOwnerReferences()
+	if init {
+		if len(data.ObjectMeta.Annotations) == 0 {
+			data.ObjectMeta.Annotations = make(map[string]string)
+		}
+
+		data.ObjectMeta.Annotations["app"] = "mysql-operator"
+		data.ObjectMeta.Annotations["mysql_cluster"] = f.cluster.Name
 	}
 
 	data.Spec = f.cluster.Spec.VolumeSpec.PersistentVolumeClaimSpec


### PR DESCRIPTION
Initial fix #73 set ownership for pvcs to mysql CRD. Kubernetes deletes the pvcs along with the CRD using its garbage cleaning design. The pods belonging to the statefulset created by CRD are not immediately terminated. Kubernetes pods have certain grace period before deletion. As a result, the PVCs get deleted first and pods later.
This works well on GKE, but causes issues on other implementations. E.g. I used it on a cluster with Datera storage provider. Datera seems to keep the volume information in the PVCs. When the PVC is deleted along with Mysql CRD, it looses that information. So when kubelet tries to delete the pod, the volume cannot be disconnected.
This fix creates a cleanup worker like reconcile worker in operator to wait till pods are deleted before deleting the corresponding pvcs.