### PR TITLE
Fix spelling, add makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,11 +72,12 @@ update-docker: $(patsubst %, hack/docker/%, $(CMDS))
 # Build the docker image
 docker-build: update-docker
 	docker build -t ${IMG} hack/docker/mysql-operator/
-	docker build  -t ${SIDECAR_IMG} hack/docker/mysql-operator-sidecar/
+	docker build -t ${SIDECAR_IMG} hack/docker/mysql-operator-sidecar/
 
 # Push the docker image
-docker-push:
+docker-push: docker-build
 	docker push ${IMG}
+	docker push ${SIDECAR_IMG}
 
 lint:
 	$(BINDIR)/golangci-lint run ./pkg/... ./cmd/...

--- a/examples/example-cluster-secret.yaml
+++ b/examples/example-cluster-secret.yaml
@@ -5,4 +5,4 @@ metadata:
 type: Opaque
 data:
   # root password is required to be specified
-  ROOT_PASSWORD:
+  ROOT_PASSWORD: bXlwYXNz

--- a/pkg/controller/orchestrator/orchestrator_controller.go
+++ b/pkg/controller/orchestrator/orchestrator_controller.go
@@ -56,7 +56,7 @@ const (
 
 var log = logf.Log.WithName(controllerName)
 
-// reconcileTimePeriod represents the time in which a cluster shoud be reconciled
+// reconcileTimePeriod represents the time in which a cluster should be reconciled
 var reconcileTimePeriod = time.Second * 5
 
 // Add creates a new MysqlCluster Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
@@ -81,7 +81,7 @@ func newReconciler(mgr manager.Manager, orcClient orc.Interface) reconcile.Recon
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 // nolint: gocyclo
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
-	// stores a mapping between cluster and it's creation event,
+	// stores a mapping between cluster and its creation event,
 	// so that we know what clusters to sync with orchestrator
 	clusters := &sync.Map{}
 
@@ -132,7 +132,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	// create a runnable function that dispatch events to events channel
+	// create a runnable function that dispatches events to events channel
 	// this runnableFunc is passed to the manager that starts it.
 	var f manager.RunnableFunc = func(stop <-chan struct{}) error {
 		for {
@@ -140,7 +140,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 			case <-stop:
 				return nil
 			case <-time.After(reconcileTimePeriod):
-				// write all clusters to envents chan to be processed
+				// write all clusters to events chan to be processed
 				clusters.Range(func(key, value interface{}) bool {
 					events <- value.(event.GenericEvent)
 					return true

--- a/pkg/controller/orchestrator/orchestrator_reconcile.go
+++ b/pkg/controller/orchestrator/orchestrator_reconcile.go
@@ -86,7 +86,7 @@ func (ou *orcUpdater) Sync() error {
 	// update cluster status accordingly with orchestrator
 	ou.updateStatusFromOrc(instances)
 
-	// get reecoveries for this cluster
+	// get recoveries for this cluster
 	if recoveries, err = ou.orcClient.AuditRecovery(ou.cluster.GetClusterAlias()); err != nil {
 		log.Error(err, "can't get recoveries from orchestrator", "alias", ou.cluster.GetClusterAlias())
 	}


### PR DESCRIPTION
Fix spelling in various files. The docker-push target does not call docker-build.
Also not sure why binaries are checked under hack/docker/* directories. In my case it created binary under hack/mysql-helper as well. That has been removed from this commit.