### PR TITLE
Add PVC cleanup: Using finalizers

### DIFF
--- a/config/rbac/rbac_role.yaml
+++ b/config/rbac/rbac_role.yaml
@@ -82,3 +82,15 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/hack/charts/mysql-operator/templates/clusterrole.yaml
+++ b/hack/charts/mysql-operator/templates/clusterrole.yaml
@@ -87,4 +87,16 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 {{- end }}

--- a/pkg/controller/add_mysqlpvc.go
+++ b/pkg/controller/add_mysqlpvc.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2018 Platform9 Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"github.com/presslabs/mysql-operator/pkg/controller/mysqlpvc"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, mysqlpvc.Add)
+}

--- a/pkg/controller/mysqlpvc/mysqlpvc_controller.go
+++ b/pkg/controller/mysqlpvc/mysqlpvc_controller.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2018 Platform9, Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mysqlpvc
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/presslabs/mysql-operator/pkg/options"
+	core "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	controllerName = "controller.mysqlpvc"
+	pvcFinalizer   = "pf9.io/MysqlPvcFinalizer"
+)
+
+var log = logf.Log.WithName(controllerName)
+
+// PvcReconciler manages lifetime of PVCs created by MysqlCluster with finalizers
+type PvcReconciler struct {
+	client.Client
+	scheme *runtime.Scheme
+	opt    *options.Options
+}
+
+func newPvcReconciler(mgr manager.Manager) *PvcReconciler {
+	return &PvcReconciler{Client: mgr.GetClient(),
+		scheme: mgr.GetScheme(),
+		opt:    options.GetOptions(),
+	}
+}
+
+// Add creates a new Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+// USER ACTION REQUIRED: update cmd/manager/main.go to call this mysql.Add(mgr) to install this Controller
+func Add(mgr manager.Manager) error {
+	return add(mgr, newPvcReconciler(mgr))
+}
+
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to PVC
+	return c.Watch(&source.Kind{Type: &core.PersistentVolumeClaim{}}, &handler.EnqueueRequestForObject{})
+}
+
+var _ reconcile.Reconciler = &PvcReconciler{}
+
+// Reconcile reads that state of the cluster for a MysqlCluster object and makes changes based on the state read
+// and what is in the MysqlCluster.Spec
+// nolint: gocyclo
+// Automatically generate RBAC rules to allow the Controller to read and write Deployments
+// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
+func (c *PvcReconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	// Fetch pvc instance
+	name := request.NamespacedName.String()
+	pvc := &core.PersistentVolumeClaim{}
+	err := c.Get(context.TODO(), request.NamespacedName, pvc)
+
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			// Object not found, return.  Created objects are automatically garbage collected.
+			// For additional cleanup logic use finalizers.
+			log.V(2).Info("not found", "pvc", name)
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		log.Error(err, "error syncing", "pvc", name)
+		return reconcile.Result{}, err
+	}
+
+	ownerRefs := pvc.GetObjectMeta().GetOwnerReferences()
+	if ownerRefs == nil || len(ownerRefs) != 1 {
+		log.V(4).Info("does not have owner reference", "pvc", name)
+		return reconcile.Result{}, nil
+	}
+
+	isInteresting := false
+
+	for _, ownerRef := range ownerRefs {
+		if ownerRef.Kind == "MysqlCluster" {
+			isInteresting = true
+			break
+		}
+	}
+
+	if !isInteresting {
+		log.V(4).Info("does not have correct owner reference", "pvc", name)
+		return reconcile.Result{}, nil
+	}
+
+	log.Info("syncing", "pvc", request.NamespacedName.String())
+
+	// Add finalizer, if not present
+	if pvc.DeletionTimestamp == nil {
+		log.V(4).Info("adding finalizer", "pvc", name)
+		addFinalizer(pvc, pvcFinalizer)
+	} else {
+		// If PVC was deleted, wait for cleanupGracePeriod and then remove finalizer
+		cleanupGracePeriod := options.GetOptions().CleanupGracePeriod
+		elapsed := time.Since(pvc.DeletionTimestamp.Time)
+		if elapsed > cleanupGracePeriod {
+			log.V(4).Info("removing finalizer", "pvc", name)
+			removeFinalizer(pvc, pvcFinalizer)
+		} else {
+			log.V(4).Info("remaining", "time", cleanupGracePeriod-elapsed)
+			return reconcile.Result{}, errors.New("Waiting for grace period to expire")
+		}
+	}
+
+	// Update original pvc
+	err = c.Update(context.TODO(), pvc)
+
+	if err != nil {
+		log.Error(err, "error updating", "pvc", name)
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func addFinalizer(in *core.PersistentVolumeClaim, finalizer string) {
+	for _, f := range in.Finalizers {
+		if f == finalizer {
+			// Already exists
+			return
+		}
+	}
+
+	in.Finalizers = append(in.Finalizers, finalizer)
+}
+
+func removeFinalizer(in *core.PersistentVolumeClaim, finalizer string) {
+	var (
+		index int
+		f     string
+	)
+	for index, f = range in.Finalizers {
+		if f == finalizer {
+			break
+		}
+	}
+
+	in.Finalizers = append(in.Finalizers[:index], in.Finalizers[index+1:]...)
+}

--- a/pkg/controller/mysqlpvc/mysqlpvc_controller_suite_test.go
+++ b/pkg/controller/mysqlpvc/mysqlpvc_controller_suite_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2018 Platform9 Inc
+Copyright 2018 Pressinfra SRL
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// nolint: errcheck
+package mysqlpvc
+
+import (
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/presslabs/mysql-operator/pkg/apis"
+)
+
+var cfg *rest.Config
+var t *envtest.Environment
+
+func TestMysqlPvcController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t, "Cleanup PVC Controller Suite", []Reporter{envtest.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func() {
+
+	// set reconcile time to 1 second to speed up the tests.
+
+	var err error
+
+	t = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds")},
+	}
+
+	apis.AddToScheme(scheme.Scheme)
+
+	cfg, err = t.Start()
+	Expect(err).NotTo(HaveOccurred())
+
+})
+
+var _ = AfterSuite(func() {
+	t.Stop()
+})
+
+// SetupTestReconcile returns a reconcile.Reconcile implementation that delegates to inner and
+// writes the request to requests after Reconcile is finished.
+func SetupTestReconcile(inner reconcile.Reconciler) (reconcile.Reconciler, chan reconcile.Request) {
+	requests := make(chan reconcile.Request)
+	fn := reconcile.Func(func(req reconcile.Request) (reconcile.Result, error) {
+		result, err := inner.Reconcile(req)
+		requests <- req
+		return result, err
+	})
+	return fn, requests
+}
+
+// StartTestManager adds recFn
+func StartTestManager(mgr manager.Manager) chan struct{} {
+	stop := make(chan struct{})
+	go func() {
+		Expect(mgr.Start(stop)).NotTo(HaveOccurred())
+	}()
+	return stop
+}

--- a/pkg/controller/mysqlpvc/mysqlpvc_controller_test.go
+++ b/pkg/controller/mysqlpvc/mysqlpvc_controller_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2018 Platform9 Inc
+Copyright 2018 Pressinfra SRL
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// nolint: errcheck
+package mysqlpvc
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"golang.org/x/net/context"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("MysqlPvc controller", func() {
+	var (
+		// channel for incoming reconcile requests
+		requests chan reconcile.Request
+		// stop channel for controller manager
+		stop chan struct{}
+		// controller k8s client
+		c client.Client
+		//timeouts
+		noReconcileTime  time.Duration
+		reconcileTimeout time.Duration
+	)
+
+	BeforeEach(func() {
+
+		var recFn reconcile.Reconciler
+
+		mgr, err := manager.New(cfg, manager.Options{})
+		Expect(err).NotTo(HaveOccurred())
+		c = mgr.GetClient()
+
+		recFn, requests = SetupTestReconcile(newPvcReconciler(mgr))
+		Expect(add(mgr, recFn)).To(Succeed())
+
+		stop = StartTestManager(mgr)
+
+	})
+
+	AfterEach(func() {
+		time.Sleep(1 * time.Second)
+		close(stop)
+	})
+
+	Describe("after creating a new pvc", func() {
+		var (
+			expectedRequest reconcile.Request
+			pvcKey          types.NamespacedName
+			pvc             *corev1.PersistentVolumeClaim
+		)
+
+		BeforeEach(func() {
+			pvcKey = types.NamespacedName{
+				Name:      fmt.Sprintf("pvc-%d", rand.Int31()),
+				Namespace: "default",
+			}
+
+			expectedRequest = reconcile.Request{
+				NamespacedName: pvcKey,
+			}
+
+			pvc = &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pvcKey.Name,
+					Namespace: pvcKey.Namespace,
+					OwnerReferences: []metav1.OwnerReference{
+						metav1.OwnerReference{
+							Kind: "MysqlCluster",
+						},
+					},
+				},
+			}
+
+			Expect(c.Create(context.TODO(), pvc)).To(Succeed())
+
+			// expect to not receive any event when a cluster is created, but
+			// just after reconcile time passed then receive a reconcile event
+			Consistently(requests, noReconcileTime).ShouldNot(Receive(Equal(expectedRequest)))
+			Eventually(requests, reconcileTimeout).Should(Receive(Equal(expectedRequest)))
+
+		})
+
+		AfterEach(func() {
+			// manually delete all created resources because GC isn't enabled in
+			// the test controller plane
+			removeAllCreatedResource(c, pvc)
+			c.Delete(context.TODO(), pvc)
+		})
+
+		It("should trigger reconciliation after noReconcileTime", func() {
+			Consistently(requests, noReconcileTime).ShouldNot(Receive(Equal(expectedRequest)))
+			Eventually(requests, reconcileTimeout).Should(Receive(Equal(expectedRequest)))
+		})
+
+		It("should re-register pvc for sync when re-starting the controller", func() {
+			// restart the controller
+			close(stop)
+			var recFn reconcile.Reconciler
+			mgr, err := manager.New(cfg, manager.Options{})
+			Expect(err).NotTo(HaveOccurred())
+			c = mgr.GetClient()
+			recFn, requests = SetupTestReconcile(newPvcReconciler(mgr))
+			Expect(add(mgr, recFn)).To(Succeed())
+			stop = StartTestManager(mgr)
+
+			// wait a second for a request
+			Consistently(requests, noReconcileTime).ShouldNot(Receive(Equal(expectedRequest)))
+			Eventually(requests, reconcileTimeout).Should(Receive(Equal(expectedRequest)))
+		})
+
+		It("should unregister pvc when deleting it from kubernetes", func() {
+			// delete the cluster
+			Expect(c.Delete(context.TODO(), pvc)).To(Succeed())
+
+			// wait few seconds for a request, in total, noReconcileTime + reconcileTimeout,
+			// to catch a reconcile event. This is the request
+			// that unregister cluster from orchestrator
+			//Eventually(requests, noReconcileTime+reconcileTimeout).Should(Receive(Equal(expectedRequest)))
+
+			//wCluster := wrapcluster.NewMysqlClusterWrapper(cluster)
+			//_, err := orcClient.Cluster(wCluster.GetClusterAlias())
+			//Expect(err).ToNot(Succeed())
+
+			// this is the requests that removes the finalizer and then the
+			// cluster is deleted
+			//Eventually(requests, noReconcileTime+reconcileTimeout).Should(Receive(Equal(expectedRequest)))
+
+			// wait few seconds without request
+			//Consistently(requests, 3*noReconcileTime).ShouldNot(Receive(Equal(expectedRequest)))
+		})
+	})
+})
+
+func removeAllCreatedResource(c client.Client, pvc *corev1.PersistentVolumeClaim) {
+	objs := []runtime.Object{
+		&corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pvc",
+				Namespace: "default",
+			},
+		},
+	}
+
+	for _, obj := range objs {
+		c.Delete(context.TODO(), obj)
+	}
+}

--- a/pkg/controller/mysqlpvc/mysqlpvc_controller_test.go
+++ b/pkg/controller/mysqlpvc/mysqlpvc_controller_test.go
@@ -162,8 +162,8 @@ func removeAllCreatedResource(c client.Client, pvc *corev1.PersistentVolumeClaim
 	objs := []runtime.Object{
 		&corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pvc",
-				Namespace: "default",
+				Name:      pvc.Name,
+				Namespace: pvc.Namespace,
 			},
 		},
 	}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -56,6 +56,7 @@ type Options struct {
 	OrchestratorTopologyUser     string
 
 	JobCompleteSuccessGraceTime time.Duration
+	CleanupGracePeriod          time.Duration
 
 	HTTPServeAddr string
 }
@@ -94,8 +95,9 @@ const (
 )
 
 var (
-	defaultHelperImage  = "quay.io/presslabs/mysql-helper:" + util.AppVersion
-	defaultJobGraceTime = 24 * time.Hour
+	defaultHelperImage        = "quay.io/presslabs/mysql-helper:" + util.AppVersion
+	defaultJobGraceTime       = 24 * time.Hour
+	defaultCleanupGracePeriod = 10 * time.Minute
 )
 
 // AddFlags registers all mysql-operator needed flags
@@ -119,8 +121,9 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.OrchestratorTopologyUser, "orchestrator-topology-user", defaultOrchestratorTopologyPassword,
 		"The orchestrator topology user. Can also be set as ORC_TOPOLOGY_USER environment variable.")
 	fs.DurationVar(&o.JobCompleteSuccessGraceTime, "job-grace-time", defaultJobGraceTime,
-		"The time in hours how jobs after completion are keept.")
-
+		"The time in hours how jobs after completion are kept.")
+	fs.DurationVar(&o.CleanupGracePeriod, "cleanup-grace-period", defaultCleanupGracePeriod,
+		"The time in minutes for which persistent volume claims are kept.")
 	fs.StringVar(&o.HTTPServeAddr, "http-serve-addr", defaultHTTPServerAddr,
 		"The address for http server.")
 }
@@ -136,9 +139,9 @@ func GetOptions() *Options {
 			HelperImage:          defaultHelperImage,
 			MetricsExporterImage: defaultExporterImage,
 
-			ImagePullPolicy:             defaultImagePullPolicy,
-			JobCompleteSuccessGraceTime: defaultJobGraceTime,
-
+			ImagePullPolicy:              defaultImagePullPolicy,
+			JobCompleteSuccessGraceTime:  defaultJobGraceTime,
+			CleanupGracePeriod:           defaultCleanupGracePeriod,
 			OrchestratorTopologyUser:     "",
 			OrchestratorTopologyPassword: "",
 


### PR DESCRIPTION
Use new kubebuilder style reconcile functions to cleanup pending PVCs. Alternative to #125

Adds new Pvc cleanup controller to watch pvc events in K8s
CleanupGracePeriod option to keep PVCs around till grace period expires
Uses finalizer to prevent Pvc deletion for CleanupGracePeriod