### PR TITLE
Change the type of value of MysqlConf from string to IntOrString

### DIFF
--- a/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
+++ b/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -118,7 +119,7 @@ type MysqlClusterSpec struct {
 
 // MysqlConf defines type for extra cluster configs. It's a simple map between
 // string and string.
-type MysqlConf map[string]string
+type MysqlConf map[string]intstr.IntOrString
 
 // PodSpec defines type for configure cluster pod spec.
 type PodSpec struct {

--- a/pkg/controller/mysqlbackupcron/mysqlbackupcron_controller_test.go
+++ b/pkg/controller/mysqlbackupcron/mysqlbackupcron_controller_test.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -155,8 +156,8 @@ var _ = Describe("MysqlBackupCron controller", func() {
 
 		It("should be just one entry for a cluster", func() {
 			// update cluster spec
-			cluster.Spec.MysqlConf = map[string]string{
-				"something": "new",
+			cluster.Spec.MysqlConf = map[string]intstr.IntOrString{
+				"something": intstr.FromString("new"),
 			}
 			Expect(c.Update(context.TODO(), cluster)).To(Succeed())
 

--- a/pkg/internal/mysqlcluster/defaults.go
+++ b/pkg/internal/mysqlcluster/defaults.go
@@ -95,7 +95,7 @@ func (cluster *MysqlCluster) SetDefaults(opt *options.Options) {
 				logFileSize = 128 * mb
 			} else if mem.Value() <= 8*gb {
 				// RAM <= 8gb
-				logFileSize = 512 * gb
+				logFileSize = 512 * mb
 			} else if mem.Value() <= 16*gb {
 				// RAM <= 16gb
 				logFileSize = 1 * gb

--- a/pkg/internal/mysqlcluster/defaults.go
+++ b/pkg/internal/mysqlcluster/defaults.go
@@ -17,10 +17,10 @@ limitations under the License.
 package mysqlcluster
 
 import (
-	"strconv"
-
+	"fmt"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/presslabs/mysql-operator/pkg/options"
 )
@@ -80,7 +80,7 @@ func (cluster *MysqlCluster) SetDefaults(opt *options.Options) {
 				bufferSize = int64(float64(mem.Value()) * 0.75)
 			}
 
-			cluster.Spec.MysqlConf["innodb-buffer-pool-size"] = strconv.FormatInt(bufferSize, 10)
+			cluster.Spec.MysqlConf["innodb-buffer-pool-size"] = humanizeSize(bufferSize)
 		}
 	}
 
@@ -104,7 +104,21 @@ func (cluster *MysqlCluster) SetDefaults(opt *options.Options) {
 				logFileSize = 2 * gb
 			}
 
-			cluster.Spec.MysqlConf["innodb-log-file-size"] = strconv.FormatInt(logFileSize, 10)
+			cluster.Spec.MysqlConf["innodb-log-file-size"] = humanizeSize(logFileSize)
 		}
 	}
+}
+
+func humanizeSize(value int64) intstr.IntOrString {
+	var unit string
+
+	if value < gb {
+		value /= mb
+		unit = "M"
+	} else {
+		value /= gb
+		unit = "G"
+	}
+
+	return intstr.FromString(fmt.Sprintf("%d%s", value, unit))
 }


### PR DESCRIPTION
1. Change type of value of MysqlConf from string to IntOrString;
2. Fix typo error of logFileSize when ram is less or equal 8GB