### PR TITLE
helm chart: Add Pod Security Policy configs

### DIFF
--- a/hack/charts/mysql-operator/templates/podsecuritypolicy.yaml
+++ b/hack/charts/mysql-operator/templates/podsecuritypolicy.yaml
@@ -8,9 +8,10 @@ metadata:
     chart: '{{ template "mysql-operator.chart" . }}'
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'
+  {{- with .Values.podSecurityPolicy.annotations }}
   annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+{{ toYaml . | indent 4 }}
+  {{- end }}
 spec:
   privileged: false
   # Required to prevent escalations to root.
@@ -29,8 +30,6 @@ spec:
   - 'projected'
   - 'secret'
   - 'downwardAPI'
-  # Assume that persistentVolumes set up by the cluster admin are safe to use.
-  - 'persistentVolumeClaim'
   hostNetwork: false
   hostIPC: false
   hostPID: false

--- a/hack/charts/mysql-operator/templates/podsecuritypolicy.yaml
+++ b/hack/charts/mysql-operator/templates/podsecuritypolicy.yaml
@@ -2,7 +2,12 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: mysql-operator
+  name: '{{ template "mysql-operator.fullname" . }}'
+  labels:
+    app: '{{ template "mysql-operator.name" . }}'
+    chart: '{{ template "mysql-operator.chart" . }}'
+    heritage: '{{ .Release.Service }}'
+    release: '{{ .Release.Name }}'
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'

--- a/hack/charts/mysql-operator/templates/podsecuritypolicy.yaml
+++ b/hack/charts/mysql-operator/templates/podsecuritypolicy.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.podSecurityPolicy }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: mysql-operator
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+  # Allow core volume types.
+  volumes:
+  - 'configMap'
+  - 'emptyDir'
+  - 'projected'
+  - 'secret'
+  - 'downwardAPI'
+  # Assume that persistentVolumes set up by the cluster admin are safe to use.
+  - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Require the container to run without root privileges.
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 99999
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+    # Forbid adding the root group.
+    - min: 1
+      max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    # Forbid adding the root group.
+    - min: 1
+      max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/hack/charts/mysql-operator/templates/podsecuritypolicy.yaml
+++ b/hack/charts/mysql-operator/templates/podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.podSecurityPolicy }}
+{{- if .Values.podSecurityPolicy.enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/hack/charts/mysql-operator/templates/role.yaml
+++ b/hack/charts/mysql-operator/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.podSecurityPolicy }}
+{{- if and .Values.podSecurityPolicy.enabled .Values.rbac.create }}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/hack/charts/mysql-operator/templates/role.yaml
+++ b/hack/charts/mysql-operator/templates/role.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.podSecurityPolicy }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mysql-operator
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - mysql-operator
+{{- end }}

--- a/hack/charts/mysql-operator/templates/role.yaml
+++ b/hack/charts/mysql-operator/templates/role.yaml
@@ -2,7 +2,12 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mysql-operator
+  name: '{{ template "mysql-operator.fullname" . }}'
+  labels:
+    app: '{{ template "mysql-operator.name" . }}'
+    chart: '{{ template "mysql-operator.chart" . }}'
+    heritage: '{{ .Release.Service }}'
+    release: '{{ .Release.Name }}'
 rules:
 - apiGroups: ['policy']
   resources: ['podsecuritypolicies']

--- a/hack/charts/mysql-operator/templates/role.yaml
+++ b/hack/charts/mysql-operator/templates/role.yaml
@@ -13,5 +13,5 @@ rules:
   resources: ['podsecuritypolicies']
   verbs:     ['use']
   resourceNames:
-  - mysql-operator
+  - '{{ template "mysql-operator.fullname" . }}'
 {{- end }}

--- a/hack/charts/mysql-operator/templates/rolebinding.yaml
+++ b/hack/charts/mysql-operator/templates/rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.podSecurityPolicy }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mysql-operator
+roleRef:
+  kind: Role
+  name: mysql-operator
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+# Authorize specific service accounts:
+- kind: ServiceAccount
+  name: {{ template "mysql-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/hack/charts/mysql-operator/templates/rolebinding.yaml
+++ b/hack/charts/mysql-operator/templates/rolebinding.yaml
@@ -2,10 +2,15 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mysql-operator
+  name: '{{ template "mysql-operator.fullname" . }}'
+  labels:
+    app: '{{ template "mysql-operator.name" . }}'
+    chart: '{{ template "mysql-operator.chart" . }}'
+    heritage: '{{ .Release.Service }}'
+    release: '{{ .Release.Name }}'
 roleRef:
   kind: Role
-  name: mysql-operator
+  name: '{{ template "mysql-operator.fullname" . }}'
   apiGroup: rbac.authorization.k8s.io
 subjects:
 # Authorize specific service accounts:

--- a/hack/charts/mysql-operator/templates/rolebinding.yaml
+++ b/hack/charts/mysql-operator/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.podSecurityPolicy }}
+{{- if and .Values.podSecurityPolicy.enabled .Values.rbac.create }}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/hack/charts/mysql-operator/values.yaml
+++ b/hack/charts/mysql-operator/values.yaml
@@ -26,7 +26,11 @@ affinity: {}
 
 extraArgs: []
 
-podSecurityPolicy: false
+podSecurityPolicy:
+  enabled: false
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
 
 rbac:
   create: true

--- a/hack/charts/mysql-operator/values.yaml
+++ b/hack/charts/mysql-operator/values.yaml
@@ -26,6 +26,8 @@ affinity: {}
 
 extraArgs: []
 
+podSecurityPolicy: false
+
 rbac:
   create: true
   serviceAccountName: default


### PR DESCRIPTION
This commit adds PodSecurityPolicy, Role and RoleBinding configs. And a
flags in values file which decides whether the PSP and related configs
will be installed or not.

Signed-off-by: Suraj Deshmukh <surajd.service@gmail.com>