### PR TITLE
Use single value for mysqlConf[ig]

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -20,7 +20,7 @@ pipeline:
 
   lint:
     group: lint
-    image: quay.io/presslabs/bfc
+    image: quay.io/presslabs/bfc:0.1
     commands:
       - make lint
 

--- a/hack/charts/mysql-cluster/templates/cluster.yaml
+++ b/hack/charts/mysql-cluster/templates/cluster.yaml
@@ -24,7 +24,7 @@ spec:
   backupURL: {{ required ".mysql.backupURL is missing" .Values.backupURL }}
   {{- end }}
 
-  {{- if .Values.mysqlConfig }}
+  {{- if .Values.mysqlConf }}
   mysqlConf:
     {{ toYaml .Values.mysqlConf | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
Right now `mysqlConfig: true` needs to be set in order for `mysqlConf` to be applied.  This is redundant when the presence of `mysqlConf` is enough for the conditional.