### PR TITLE
Change option "master_info_repository" to "master-info-repository"

### DIFF
--- a/pkg/controller/mysqlcluster/internal/syncer/config_map.go
+++ b/pkg/controller/mysqlcluster/internal/syncer/config_map.go
@@ -155,7 +155,7 @@ var mysqlMasterSlaveConfigs = map[string]string{
 	"relay-log-recovery":        "on",
 
 	// https://github.com/github/orchestrator/issues/323#issuecomment-338451838
-	"master_info_repository": "TABLE",
+	"master-info-repository": "TABLE",
 
 	"default-storage-engine":   "InnoDB",
 	"gtid-mode":                "on",


### PR DESCRIPTION
Since other default mysql options use this nameing style, it's better to make them consistent.