### PR TITLE
Change option "master_info_repository" to "master-info-repository"

### DIFF
--- a/pkg/controller/mysqlcluster/internal/syncer/config_map.go
+++ b/pkg/controller/mysqlcluster/internal/syncer/config_map.go
@@ -155,7 +155,7 @@ var mysqlMasterSlaveConfigs = map[string]string{
 	"relay-log-recovery":        "on",
 
 	// https://github.com/github/orchestrator/issues/323#issuecomment-338451838
-	"master_info_repository": "TABLE",
+	"master-info-repository": "TABLE",
 
 	"default-storage-engine":   "InnoDB",
 	"gtid-mode":                "on",

--- a/pkg/sidecar/appclone.go
+++ b/pkg/sidecar/appclone.go
@@ -26,7 +26,7 @@ import (
 // RunCloneCommand clone the data from source.
 // nolint: gocyclo
 func RunCloneCommand(cfg *Config) error {
-	log.Info("clonning command", "host", cfg.Hostname)
+	log.Info("cloning command", "host", cfg.Hostname)
 
 	// skip cloning if data exists.
 	if !shouldBootstrapNode() {
@@ -35,7 +35,7 @@ func RunCloneCommand(cfg *Config) error {
 	}
 
 	if checkIfDataExists() {
-		log.Info("data alerady exists! Remove manually PVC to cleanup or to reinitialize.")
+		log.Info("data already exists! Remove manually PVC to cleanup or to reinitialize.")
 		return nil
 	}
 


### PR DESCRIPTION
Since other default mysql options use this naming style, it's better to make them consistent.
