### PR TITLE
Support GCP app default credentials for backups/sidecar

### DIFF
--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -26,8 +26,8 @@ RUN apt-get update \
 COPY hack/docker/rclone.gpg /root/rclone.gpg
 RUN gpg --import /root/rclone.gpg
 
-RUN wget -nv https://github.com/ncw/rclone/releases/download/v1.46/rclone-v1.46-linux-amd64.zip \
-    && wget -nv https://github.com/ncw/rclone/releases/download/v1.46/SHA256SUMS \
+RUN wget -nv https://github.com/ncw/rclone/releases/download/v1.48.0/rclone-v1.48.0-linux-amd64.zip \
+    && wget -nv https://github.com/ncw/rclone/releases/download/v1.48.0/SHA256SUMS \
     && gpg --verify --output=- SHA256SUMS > sums \
     && sha256sum -c --ignore-missing sums \
     && unzip rclone-*-linux-amd64.zip \

--- a/hack/docker/sidecar-entrypoint.sh
+++ b/hack/docker/sidecar-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 echo "Create rclone.conf file."

--- a/hack/docker/sidecar-entrypoint.sh
+++ b/hack/docker/sidecar-entrypoint.sh
@@ -15,12 +15,7 @@ acl = ${AWS_ACL}
 storage_class = ${AWS_STORAGE_CLASS}
 [gs]
 type = google cloud storage
-project_number = ${GCS_PROJECT_ID}
-service_account_file = /tmp/google-credentials.json
 object_acl = ${GCS_OBJECT_ACL}
-bucket_acl = ${GCS_BUCKET_ACL}
-location =  ${GCS_LOCATION}
-storage_class = ${GCS_STORAGE_CLASS:-"MULTI_REGIONAL"}
 [http]
 type = http
 url = ${HTTP_URL}

--- a/hack/docker/sidecar-entrypoint.sh
+++ b/hack/docker/sidecar-entrypoint.sh
@@ -15,7 +15,12 @@ acl = ${AWS_ACL}
 storage_class = ${AWS_STORAGE_CLASS}
 [gs]
 type = google cloud storage
+project_number = ${GCS_PROJECT_ID}
+service_account_file = /tmp/google-credentials.json
 object_acl = ${GCS_OBJECT_ACL}
+bucket_acl = ${GCS_BUCKET_ACL}
+location =  ${GCS_LOCATION}
+storage_class = ${GCS_STORAGE_CLASS:-"MULTI_REGIONAL"}
 [http]
 type = http
 url = ${HTTP_URL}
@@ -25,10 +30,14 @@ account = ${AZUREBLOB_ACCOUNT}
 key = ${AZUREBLOB_KEY}
 EOF
 
-echo "Create google-credentials.json file."
-cat <<EOF > /tmp/google-credentials.json
-${GCS_SERVICE_ACCOUNT_JSON_KEY}
+if [[ -n "${GCS_SERVICE_ACCOUNT_JSON_KEY:-}" ]]; then 
+    echo "Create google-credentials.json file."
+    cat <<EOF > /tmp/google-credentials.json
+    ${GCS_SERVICE_ACCOUNT_JSON_KEY}
 EOF
+else 
+    touch /tmp/google-credentials.json
+fi
 
 SIDECAR_BIN=mysql-operator-sidecar
 VERBOSE="--debug"

--- a/pkg/controller/mysqlbackup/internal/syncer/job.go
+++ b/pkg/controller/mysqlbackup/internal/syncer/job.go
@@ -133,6 +133,14 @@ func (s *jobSyncer) ensurePodSpec(in core.PodSpec) core.PodSpec {
 		s.backup.GetBackupURL(s.cluster),
 	}
 
+	in.ServiceAccountName = s.cluster.Spec.PodSpec.ServiceAccountName
+
+	in.Affinity = s.cluster.Spec.PodSpec.Affinity
+	in.ImagePullSecrets = s.cluster.Spec.PodSpec.ImagePullSecrets
+	in.NodeSelector = s.cluster.Spec.PodSpec.NodeSelector
+	in.PriorityClassName = s.cluster.Spec.PodSpec.PriorityClassName
+	in.Tolerations = s.cluster.Spec.PodSpec.Tolerations
+
 	boolTrue := true
 	in.Containers[0].Env = []core.EnvVar{
 		{


### PR DESCRIPTION
This PR aims to support GCP application default credentials in addition to specifying a fixed Service Account JSON key, so the new [GKE Workload Identity authentication](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) for Pods can be used. See also #274

To support those two (GCP app default + Workload Identity), the following changes are necessary:

- update rclone in sidecar (GCP app default credentials are only supported from rclone 1.47.0)
- create an empty GCP service account key file for rclone in case no credentials are specified (so rclone uses app default authentication)
  - this is important for backups as well as inits of new clusters from those backups
- add the same additional Pod Spec options that the accompanying MySQL Cluster has to make sure
  - Backup Pods can use a non-default Service Account
  - Backup Pods get scheduled on Nodes that are part of the correct GKE Identity Namespace (usually the same where the MySQL StatefulSet Pods are running)
  - use the same account as the MySQL Cluster Pods to make sure they have the same identity for backups and inits to read/write from/to GCS buckets

We use this internally now successfully and welcome any feedback on this and like to contribute on that :) 