### PR TITLE
Extend operator to accept custom version map

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ bin/orc-helper_linux_amd64: $(shell hack/development/related-go-files.sh $(PKG_N
 skaffold-build: bin/mysql-operator_linux_amd64 bin/mysql-operator-sidecar_linux_amd64 bin/orc-helper_linux_amd64
 
 skaffold-run: skaffold-build
-	skaffold run
+	skaffold run --cache-artifacts=true
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet

--- a/config/crds/mysql_v1alpha1_mysqlcluster.yaml
+++ b/config/crds/mysql_v1alpha1_mysqlcluster.yaml
@@ -7,6 +7,10 @@ metadata:
   name: mysqlclusters.mysql.presslabs.org
 spec:
   additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type == "Ready")].status
+    description: The cluster status
+    name: Ready
+    type: string
   - JSONPath: .spec.replicas
     description: The number of desired nodes
     name: Replicas

--- a/config/crds/mysql_v1alpha1_mysqlcluster.yaml
+++ b/config/crds/mysql_v1alpha1_mysqlcluster.yaml
@@ -6,6 +6,14 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: mysqlclusters.mysql.presslabs.org
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.replicas
+    description: The number of desired nodes
+    name: Replicas
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: mysql.presslabs.org
   names:
     kind: MysqlCluster
@@ -54,7 +62,8 @@ spec:
               type: string
             image:
               description: To specify the image that will be used for mysql server
-                container. If this is specified then the mysqlVersion is ignored.
+                container. If this is specified then the mysqlVersion is used as source
+                for MySQL server version.
               type: string
             initBucketSecretName:
               type: string
@@ -80,7 +89,11 @@ spec:
               description: A map[string]string that will be passed to my.cnf file.
               type: object
             mysqlVersion:
-              description: Represents the percona image tag. Defaults to 5.7
+              description: 'Represents the MySQL version that will be run. The available
+                version can be found here: https://github.com/presslabs/mysql-operator/blob/0fd4641ce4f756a0aab9d31c8b1f1c44ee10fcb2/pkg/util/constants/constants.go#L87
+                This field should be set even if the Image is set to let the operator
+                know which mysql version is running. Based on this version the operator
+                can take decisions which features can be used. Defaults to 5.7'
               type: string
             podSpec:
               description: Pod extra specification

--- a/hack/charts/mysql-operator/templates/crds.yaml
+++ b/hack/charts/mysql-operator/templates/crds.yaml
@@ -33,6 +33,10 @@ metadata:
     helm.sh/hook: crd-install
 spec:
   additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type == "Ready")].status
+    description: The cluster status
+    name: Ready
+    type: string
   - JSONPath: .spec.replicas
     description: The number of desired nodes
     name: Replicas

--- a/hack/charts/mysql-operator/templates/crds.yaml
+++ b/hack/charts/mysql-operator/templates/crds.yaml
@@ -32,6 +32,14 @@ metadata:
   annotations:
     helm.sh/hook: crd-install
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.replicas
+    description: The number of desired nodes
+    name: Replicas
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: mysql.presslabs.org
   names:
     kind: MysqlCluster

--- a/hack/charts/mysql-operator/templates/orc-ingress.yaml
+++ b/hack/charts/mysql-operator/templates/orc-ingress.yaml
@@ -1,36 +1,36 @@
 {{- if .Values.orchestrator.ingress.enabled -}}
-        {{- $fullName := include "mysql-operator.fullname" . -}}
+{{- $fullName := include "mysql-operator.fullname" . -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-    name: {{ $fullName }}
-    labels:
-        {{ include "mysql-operator.labels" . | indent 4 }}
-        {{- with .Values.orchestrator.ingress.annotations }}
-    annotations:
-        {{- toYaml . | nindent 4 }}
-        {{- end }}
+  name: {{ $fullName }}
+  labels:
+    {{ include "mysql-operator.labels" . | indent 4 }}
+    {{- with .Values.orchestrator.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
-        {{- if .Values.orchestrator.ingress.tls }}
-    tls:
-            {{- range .Values.orchestrator.ingress.tls }}
-    - hosts:
-              {{- range .hosts }}
-      - {{ . | quote }}
-            {{- end }}
-      secretName: {{ .secretName }}
-        {{- end }}
-        {{- end }}
-    rules:
-            {{- range .Values.orchestrator.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-          paths:
-                  {{- range .paths }}
-          - path: {{ . }}
-            backend:
-                serviceName: {{ $fullName }}
-                servicePort: http
-        {{- end }}
-        {{- end }}
-        {{- end }}
+  {{- if .Values.orchestrator.ingress.tls }}
+  tls:
+  {{- range .Values.orchestrator.ingress.tls }}
+  - hosts:
+    {{- range .hosts }}
+    - {{ . | quote }}
+    {{- end }}
+    secretName: {{ .secretName }}
+  {{- end }}
+  {{- end }}
+  rules:
+  {{- range .Values.orchestrator.ingress.hosts }}
+  - host: {{ .host | quote }}
+    http:
+      paths:
+      {{- range .paths }}
+      - path: {{ . }}
+        backend:
+          serviceName: {{ $fullName }}
+          servicePort: http
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/hack/charts/mysql-operator/templates/orc-service.yaml
+++ b/hack/charts/mysql-operator/templates/orc-service.yaml
@@ -9,12 +9,12 @@ and for routing/proxying to the leader.
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{$fullName}}-{{$i}}-svc"
+  name: {{ $fullName }}-{{ $i }}-svc
   labels:
-    app: "{{$fullName}}"
-    chart: {{$chart}}
-    release: "{{ $.Release.Name }}"
-    heritage: "{{ $.Release.Service }}"
+    app: {{ $fullName }}
+    chart: {{ $chart }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
@@ -27,14 +27,14 @@ spec:
     port: 10008
     targetPort: 10008
   selector:
-    statefulset.kubernetes.io/pod-name: {{$fullName}}-{{$i}}
+    statefulset.kubernetes.io/pod-name: {{ $fullName }}-{{ $i }}
 ---
 {{end}}
 {{/*{orchestrator will make sure that this service always talks to the leader}*/}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ template "mysql-operator.fullname" . }}"
+  name: {{ template "mysql-operator.fullname" . }}
   labels:
     app: {{ template "mysql-operator.name" . }}
     chart: {{ template "mysql-operator.chart" . }}
@@ -49,6 +49,6 @@ spec:
     port: {{ .Values.orchestrator.service.port }}
     protocol: TCP
     targetPort: 3000
-          {{- if .Values.orchestrator.service.nodePort }}
+    {{- if .Values.orchestrator.service.nodePort }}
     nodePort: {{ .Values.orchestrator.service.nodePort }}
-        {{- end }}
+    {{- end }}

--- a/hack/charts/mysql-operator/values.yaml
+++ b/hack/charts/mysql-operator/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicas: 3
+replicas: 1
 image: quay.io/presslabs/mysql-operator:latest
 sidecarImage: quay.io/presslabs/mysql-operator-sidecar:latest
 imagePullPolicy: IfNotPresent

--- a/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
+++ b/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
@@ -282,6 +282,7 @@ type MysqlClusterStatus struct {
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.readyNodes
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type == "Ready")].status",description="The cluster status"
 // +kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".spec.replicas",description="The number of desired nodes"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type MysqlCluster struct {

--- a/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
+++ b/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
@@ -43,13 +43,16 @@ type MysqlClusterSpec struct {
 	// +kubebuilder:validation:MaxLength=63
 	SecretName string `json:"secretName"`
 
-	// Represents the percona image tag.
+	// Represents the MySQL version that will be run. The available version can be found here:
+	// https://github.com/presslabs/mysql-operator/blob/0fd4641ce4f756a0aab9d31c8b1f1c44ee10fcb2/pkg/util/constants/constants.go#L87
+	// This field should be set even if the Image is set to let the operator know which mysql version is running.
+	// Based on this version the operator can take decisions which features can be used.
 	// Defaults to 5.7
 	// +optional
 	MysqlVersion string `json:"mysqlVersion,omitempty"`
 
 	// To specify the image that will be used for mysql server container.
-	// If this is specified then the mysqlVersion is ignored.
+	// If this is specified then the mysqlVersion is used as source for MySQL server version.
 	// +optional
 	Image string `json:"image,omitempty"`
 

--- a/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
+++ b/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
@@ -282,6 +282,8 @@ type MysqlClusterStatus struct {
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.readyNodes
+// +kubebuilder:printcolumn:name="Replicas",type="integer",JSONPath=".spec.replicas",description="The number of desired nodes"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type MysqlCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/internal/mysqlcluster/mysqlcluster.go
+++ b/pkg/internal/mysqlcluster/mysqlcluster.go
@@ -18,6 +18,7 @@ package mysqlcluster
 
 import (
 	"fmt"
+	"github.com/presslabs/mysql-operator/pkg/options"
 	"strings"
 
 	"github.com/blang/semver"
@@ -190,6 +191,12 @@ func (c *MysqlCluster) GetMysqlImage() string {
 		return c.Spec.Image
 	}
 
+	// check if the user set some overrides
+	opt := options.GetOptions()
+	if img, ok := opt.MySQLVersionImageOverride[c.GetMySQLSemVer().String()]; ok {
+		return img
+	}
+
 	if img, ok := constants.MysqlImageVersions[c.GetMySQLSemVer().String()]; ok {
 		return img
 	}
@@ -212,5 +219,5 @@ func (c *MysqlCluster) UpdateSpec() {
 func (c *MysqlCluster) ShouldHaveInitContainerForMysql() bool {
 	expectedRange := semver.MustParseRange(">=5.7.26 <8.0.0 || >=8.0.15")
 
-	return strings.HasPrefix(c.GetMysqlImage(), "percona") && expectedRange(c.GetMySQLSemVer())
+	return strings.Contains(c.GetMysqlImage(), "percona") && expectedRange(c.GetMySQLSemVer())
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -140,7 +140,7 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 		"The namespace to restrict the client to watch objects.")
 
 	fs.StringToStringVar(&o.MySQLVersionImageOverride, "mysql-versions-to-image", map[string]string{},
-		"A map to override default image for different mysql versions.")
+		"A map to override default image for different mysql versions. Example: 5.7.23=mysql:5.7,5.7.24=mysql:5.7")
 }
 
 var instance *Options

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -65,6 +65,10 @@ type Options struct {
 
 	// Namespace where to look after objects. This will limit the operator action range.
 	Namespace string
+
+	// MySQLVersionImageOverride define a map between MySQL version and image.
+	// This overrides the default versions and has priority.
+	MySQLVersionImageOverride map[string]string
 }
 
 type pullpolicy corev1.PullPolicy
@@ -89,7 +93,7 @@ func newPullPolicyValue(defaultValue corev1.PullPolicy, v *corev1.PullPolicy) *p
 }
 
 const (
-	defaultExporterImage = "prom/mysqld-exporter:latest"
+	defaultExporterImage = "prom/mysqld-exporter:v0.11.0"
 
 	defaultImagePullPolicy     = corev1.PullIfNotPresent
 	defaultImagePullSecretName = ""
@@ -134,6 +138,9 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&o.Namespace, "namespace", defaultNamespace,
 		"The namespace to restrict the client to watch objects.")
+
+	fs.StringToStringVar(&o.MySQLVersionImageOverride, "mysql-versions-to-image", map[string]string{},
+		"A map to override default image for different mysql versions.")
 }
 
 var instance *Options


### PR DESCRIPTION
 * This PR introduces a new command line flag, `--mysql-versions-to-image`. which allows to override default  versions [table](https://github.com/presslabs/mysql-operator/blob/0fd4641ce4f756a0aab9d31c8b1f1c44ee10fcb2/pkg/util/constants/constants.go#L87).
 * Pin `mysqld` Prometheus exporter image to `v0.11.0`
 * Adds to `mysqlcluster` CRD new printable columns `Ready`, `Replicas` and `Age`