### PR TITLE
Don't limit memory

### DIFF
--- a/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
+++ b/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
@@ -529,8 +529,7 @@ func (s *sfsSyncer) getLabels(extra map[string]string) map[string]string {
 
 func (s *sfsSyncer) ensureResources(name string) core.ResourceRequirements {
 	limits := core.ResourceList{
-		core.ResourceCPU:    resource.MustParse("100m"),
-		core.ResourceMemory: resource.MustParse("1Gi"),
+		core.ResourceCPU: resource.MustParse("100m"),
 	}
 	requests := core.ResourceList{
 		core.ResourceCPU: resource.MustParse("30m"),


### PR DESCRIPTION
Limiting the memory will set also the requested memory to 1G if not set. In the end-to-end test environment is too much memory requested and the tests fail.