### PR TITLE
removed 4 spaces because labels already indented

### DIFF
--- a/hack/charts/mysql-operator/templates/orc-ingress.yaml
+++ b/hack/charts/mysql-operator/templates/orc-ingress.yaml
@@ -5,7 +5,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    {{ include "mysql-operator.labels" . | indent 4 }}
+{{ include "mysql-operator.labels" . | indent 4 }}
     {{- with .Values.orchestrator.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
```apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: mysql-operator
  labels:
        app.kubernetes.io/name: mysql-operator
    helm.sh/chart: mysql-operator-0.3.0
    app.kubernetes.io/instance: mysql-operator
    app.kubernetes.io/version: "v0.3.0"
    app.kubernetes.io/managed-by: Tiller```