### PR TITLE
Do not change cluster's read-only status during failover

### DIFF
--- a/pkg/controller/orchestrator/orchestrator_reconcile.go
+++ b/pkg/controller/orchestrator/orchestrator_reconcile.go
@@ -486,7 +486,8 @@ func (ou *orcUpdater) markReadOnlyNodesInOrc(insts InstancesSet, master *orc.Ins
 	// If there is an in-progress failover, we will not interfere with readable/writable status on this iteration.
 	fip := ou.cluster.GetClusterCondition(api.ClusterConditionFailoverInProgress)
 	if fip != nil && fip.Status == core.ConditionTrue {
-		log.Info("cluster has a failover in progress, will delay setting readable/writeable status until failover is complete", "cluster", ou.cluster.Name, "since", fip.LastTransitionTime)
+		log.Info("cluster has a failover in progress, will delay setting readable/writeable status until failover is complete",
+			"cluster", ou.cluster.Name, "since", fip.LastTransitionTime)
 		return
 	}
 	var err error

--- a/pkg/controller/orchestrator/orchestrator_reconcile_test.go
+++ b/pkg/controller/orchestrator/orchestrator_reconcile_test.go
@@ -420,7 +420,7 @@ var _ = Describe("Orchestrator reconciler", func() {
 		It("should not set the master writable during failover", func() {
 			// Get master
 			insts, _ := orcClient.Cluster(cluster.GetClusterAlias())
-			master := InstancesSet(insts).GetInstance(cluster.GetPodHostname(0)) // set node0 as master
+			master := InstancesSet(insts).GetInstance(cluster.GetPodHostname(0))
 
 			// Simulate failover status:
 			//  1. Orchestrator would have set read-only on the master, and

--- a/pkg/controller/orchestrator/orchestrator_reconcile_test.go
+++ b/pkg/controller/orchestrator/orchestrator_reconcile_test.go
@@ -425,7 +425,9 @@ var _ = Describe("Orchestrator reconciler", func() {
 			// Simulate failover status:
 			//  1. Orchestrator would have set read-only on the master, and
 			//  2. ClusterConditionFailoverInProgress would be set to true
-			updater.setReadOnlyNode(*master)
+			err := updater.setReadOnlyNode(*master)
+			Expect(err).To(Succeed())
+
 			cluster.UpdateStatusCondition(api.ClusterConditionFailoverInProgress, core.ConditionTrue,
 				"TestFailover", "Failover is in progress")
 


### PR DESCRIPTION
As reported in in #411, there is a period of time during a failover where we could incorrectly allow writes to the old master by [setting it to writable](https://github.com/presslabs/mysql-operator/blob/master/pkg/controller/orchestrator/orchestrator_reconcile.go#L507-L510) during the reconciliation loop. 

This PR intentionally skips the `markReadOnlyNodesInOrc` function while the `ClusterConditionFailoverInProgress` status condition is set to true. This means that, during the brief timeframe that Orchestrator is demoting the old master and promoting a new one, we will not interfere with the read-only/writable status of any of the instances. 

Once the failover completes, the `ClusterConditionFailoverInProgress` will [be cleared](https://github.com/presslabs/mysql-operator/blob/master/pkg/controller/orchestrator/orchestrator_reconcile.go#L263-L264) in a subsequent iteration and `markReadOnlyNodesInOrc` will be permitted to run as usual.

Both the `e2e-local` and regular tests pass for me, including [the new one](https://github.com/dougfales/mysql-operator/blob/b6bfeecea1d49a8135bc3b5287082cbe982d5854/pkg/controller/orchestrator/orchestrator_reconcile_test.go#L420-L447), which would fail without c54aad0efed4c543c216f5f6c9190b2bd31a24df .

