### PR TITLE
Log cluster/master name instead of entire object when reconciling

### DIFF
--- a/pkg/controller/orchestrator/orchestrator_controller.go
+++ b/pkg/controller/orchestrator/orchestrator_controller.go
@@ -188,7 +188,7 @@ func (r *ReconcileMysqlCluster) Reconcile(request reconcile.Request) (reconcile.
 
 	// save old status
 	status := *cluster.Status.DeepCopy()
-	log.Info("reconciling cluster", "cluster", cluster)
+	log.Info("reconciling cluster", "cluster", request.NamespacedName.String())
 
 	// this syncer mutates the cluster and updates it. Should be the first syncer
 	finSyncer := newFinalizerSyncer(r.Client, r.scheme, cluster, r.orcClient)

--- a/pkg/controller/orchestrator/orchestrator_reconcile.go
+++ b/pkg/controller/orchestrator/orchestrator_reconcile.go
@@ -259,7 +259,6 @@ func (ou *orcUpdater) updateStatusFromOrc(insts InstancesSet, master *orc.Instan
 
 	// check if the master is up to date and is not downtime to remove in progress failover condition
 	if master != nil && master.SecondsSinceLastSeen.Valid && master.SecondsSinceLastSeen.Int64 < 5 {
-		log.Info("cluster failover finished", "master", master)
 		ou.cluster.UpdateStatusCondition(api.ClusterConditionFailoverInProgress, core.ConditionFalse,
 			"ClusterMasterHealthy", "Master is healthy in orchestrator")
 	}


### PR DESCRIPTION
There's a slight inconsistency in the JSON logs from the orchestrator where it usually logs the name of the cluster or master when reconciling - except for when logging "reconciling cluster" where the `cluster` key in the JSON output contains the entire `MysqlCluster` API resource.

This is causing a slight problem in our logging infrastructure where we have Beats picking up container logs and feeding them to Elasticsearch and it's unable to map these messages to the Elasticsearch index (eg. `object mapping for [json.cluster] tried to parse field [cluster] as object, but found a concrete value`).

This also removes a similar problem during when logging "cluster failover finished" where the entire master object was logged; this log statement has been removed as per @AMecea's suggestion. This also fixes #414 where there was some confusion around whether or not a failover had happened when seeing this log statement logged continuously.