### PR TITLE
Clone from k8s services instead of individual hosts

### DIFF
--- a/cmd/mysql-operator-sidecar/main.go
+++ b/cmd/mysql-operator-sidecar/main.go
@@ -65,7 +65,7 @@ func main() {
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := sidecar.RunCloneCommand(cfg); err != nil {
 				log.Error(err, "clone command failed")
-				os.Exit(1)
+				os.Exit(8)
 			}
 			if err := sidecar.RunConfigCommand(cfg); err != nil {
 				log.Error(err, "init command failed")

--- a/pkg/controller/mysqlcluster/mysqlcluster_controller.go
+++ b/pkg/controller/mysqlcluster/mysqlcluster_controller.go
@@ -214,6 +214,7 @@ func (r *ReconcileMysqlCluster) Reconcile(request reconcile.Request) (reconcile.
 		clustersyncer.NewHeadlessSVCSyncer(r.Client, r.scheme, cluster),
 		clustersyncer.NewMasterSVCSyncer(r.Client, r.scheme, cluster),
 		clustersyncer.NewHealthySVCSyncer(r.Client, r.scheme, cluster),
+		clustersyncer.NewHealthyReplicasSVCSyncer(r.Client, r.scheme, cluster),
 
 		clustersyncer.NewStatefulSetSyncer(r.Client, r.scheme, cluster, cmRev, sctRev, r.opt),
 	}

--- a/pkg/internal/mysqlcluster/mysqlcluster.go
+++ b/pkg/internal/mysqlcluster/mysqlcluster.go
@@ -111,7 +111,9 @@ const (
 	ConfigMap ResourceName = "config-files"
 	// MasterService is the name of the service that points to master node
 	MasterService ResourceName = "master-service"
-	// HealthyNodesService is the name of a service that continas all healthy nodes
+	// HealthyReplicasService is the name of a service that points healthy replicas (excludes master)
+	HealthyReplicasService ResourceName = "healthy-replicas-service"
+	// HealthyNodesService is the name of a service that contains all healthy nodes
 	HealthyNodesService ResourceName = "healthy-nodes-service"
 	// PodDisruptionBudget is the name of pod disruption budget for the stateful set
 	PodDisruptionBudget ResourceName = "pdb"
@@ -131,6 +133,8 @@ func GetNameForResource(name ResourceName, clusterName string) string {
 		return fmt.Sprintf("%s-mysql", clusterName)
 	case MasterService:
 		return fmt.Sprintf("%s-mysql-master", clusterName)
+	case HealthyReplicasService:
+		return fmt.Sprintf("%s-mysql-replicas", clusterName)
 	case HeadlessSVC:
 		return HeadlessSVCName
 	case OldHeadlessSVC:

--- a/pkg/sidecar/appclone.go
+++ b/pkg/sidecar/appclone.go
@@ -91,11 +91,7 @@ func RunCloneCommand(cfg *Config) error {
 	}
 
 	// prepare backup
-	if err := xtrabackupPrepareData(); err != nil {
-		return err
-	}
-
-	return nil
+	return xtrabackupPrepareData()
 }
 
 func isServiceAvailable(svc string) bool {

--- a/pkg/sidecar/appclone.go
+++ b/pkg/sidecar/appclone.go
@@ -100,7 +100,7 @@ func isServiceAvailable(svc string) bool {
 	}
 
 	client := &http.Client{}
-	client.Transport = fastTimeoutTransport(5)
+	client.Transport = transportWithTimeout(serverConnectTimeout)
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Info("service was not available", "service", svc, "error", err)

--- a/pkg/sidecar/appclone.go
+++ b/pkg/sidecar/appclone.go
@@ -52,7 +52,7 @@ import (
 // master; bucket URL exists | The assumption is that this is the bootstrap case: the
 //                           | very first mysql pod is being initialized.
 // ------------------------------------------------------------------------------------
-// No healthy replcias; no   | If this is the first pod in the cluster, then allow it
+// No healthy replicas; no   | If this is the first pod in the cluster, then allow it
 // master; no bucket URL     | to initialize as an empty instance, otherwise, return an
 //                           | error to allow k8s to kill and restart the pod.
 // ------------------------------------------------------------------------------------

--- a/pkg/sidecar/appclone.go
+++ b/pkg/sidecar/appclone.go
@@ -93,7 +93,7 @@ func RunCloneCommand(cfg *Config) error {
 }
 
 func isServiceAvailable(svc string) bool {
-	req, err := http.NewRequest("GET", prepareUrl(svc, serverProbeEndpoint), nil)
+	req, err := http.NewRequest("GET", prepareURL(svc, serverProbeEndpoint), nil)
 	if err != nil {
 		log.Info("failed to check available service", "service", svc, "error", err)
 		return false

--- a/pkg/sidecar/appclone_fakeserver_test.go
+++ b/pkg/sidecar/appclone_fakeserver_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 Harvest
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package sidecar
 
 import (

--- a/pkg/sidecar/appclone_fakeserver_test.go
+++ b/pkg/sidecar/appclone_fakeserver_test.go
@@ -52,7 +52,7 @@ func newFakeServer(address string, cfg *Config) *fakeServer {
 func (fSrv *fakeServer) waitReady() error {
 	retries := 0
 	for {
-		resp, err := http.Get(prepareUrl(fSrv.server.Addr, serverProbeEndpoint))
+		resp, err := http.Get(prepareURL(fSrv.server.Addr, serverProbeEndpoint))
 		if err == nil && resp.StatusCode == 200 {
 			return nil
 		}

--- a/pkg/sidecar/appclone_fakeserver_test.go
+++ b/pkg/sidecar/appclone_fakeserver_test.go
@@ -1,0 +1,135 @@
+package sidecar
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type loggedRequest struct {
+	endpoint  string
+	timestamp time.Time
+}
+
+type fakeServer struct {
+	cfg              *Config
+	server           http.Server
+	calls            []loggedRequest
+	simulateTruncate bool // Will cause the next request to truncate the response
+	simulateError    bool // Will cause the next request to return http error
+	validXBStream    []byte
+}
+
+func newFakeServer(address string, cfg *Config) *fakeServer {
+	mux := http.NewServeMux()
+	fSrv := &fakeServer{
+		cfg: cfg,
+		server: http.Server{
+			Addr:    address,
+			Handler: mux,
+		},
+	}
+
+	// A small file named "t" containing the text "fake-backup", encoded with xbstream -c
+	fSrv.validXBStream = []byte{
+		0x58, 0x42, 0x53, 0x54, 0x43, 0x4b, 0x30, 0x31, 0x00, 0x50, 0x01, 0x00, 0x00, 0x00, 0x74, 0x0c, // XBSTCK01.P....t.
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x6b, // ...............k
+		0xcc, 0x84, 0x00, 0x66, 0x61, 0x6b, 0x65, 0x2d, 0x62, 0x61, 0x63, 0x6b, 0x75, 0x70, 0x0a, 0x58, // ...fake-backup.X
+		0x42, 0x53, 0x54, 0x43, 0x4b, 0x30, 0x31, 0x00, 0x45, 0x01, 0x00, 0x00, 0x00, 0x74, // BSTCK01.E....t.
+	}
+
+	fSrv.reset()
+
+	mux.Handle(serverProbeEndpoint, http.HandlerFunc(fSrv.healthHandler))
+	mux.Handle(serverBackupEndpoint, http.HandlerFunc(fSrv.backupHandler))
+
+	return fSrv
+}
+
+// Since we are starting/stopping these fake servers for individual test cases, we should wait
+// for them to startup so as to avoid false positives in our tests.
+func (fSrv *fakeServer) waitReady() error {
+	retries := 0
+	for {
+		resp, err := http.Get(prepareUrl(fSrv.server.Addr, serverProbeEndpoint))
+		if err == nil && resp.StatusCode == 200 {
+			return nil
+		}
+		if retries++; retries > 5 {
+			return fmt.Errorf("could not start fake sidecar server: %s", err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func (fSrv *fakeServer) start() error {
+	go func() {
+		err := fSrv.server.ListenAndServe()
+		if err != nil && err != http.ErrServerClosed {
+			panic("couldn't start fakeserver")
+		}
+	}()
+	return fSrv.waitReady()
+}
+
+func (fSrv *fakeServer) stop() error {
+	if err := fSrv.server.Shutdown(context.Background()); err != nil {
+		return fmt.Errorf("failed to stop appclone test server: %s", err)
+	}
+	return nil
+}
+
+func (fSrv *fakeServer) reset() {
+	fSrv.calls = make([]loggedRequest, 0)
+	fSrv.simulateError = false
+	fSrv.simulateTruncate = false
+}
+
+func (fSrv *fakeServer) backupRequestsReceived() int {
+	return fSrv.callsForEndpoint(serverBackupEndpoint)
+}
+
+func (fSrv *fakeServer) callsForEndpoint(endpoint string) int {
+	count := 0
+	for _, call := range fSrv.calls {
+		if call.endpoint == endpoint {
+			count++
+		}
+	}
+	return count
+}
+
+func (fSrv *fakeServer) healthHandler(w http.ResponseWriter, req *http.Request) {
+	fSrv.calls = append(fSrv.calls, loggedRequest{req.RequestURI, time.Now()})
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write([]byte("OK")); err != nil {
+		log.Error(err, "failed writing request")
+	}
+}
+
+func (fSrv *fakeServer) backupHandler(w http.ResponseWriter, req *http.Request) {
+	fSrv.calls = append(fSrv.calls, loggedRequest{req.RequestURI, time.Now()})
+
+	// Error: return http status code of 500
+	if fSrv.simulateError {
+		http.Error(w, "xtrbackup failed", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Trailer", backupStatusTrailer)
+
+	backup := fSrv.validXBStream
+	// Truncate: send half the stream, with "successful" trailers
+	if fSrv.simulateTruncate {
+		backup = fSrv.validXBStream[0:10]
+	}
+
+	if _, err := w.Write(backup); err != nil {
+		log.Error(err, "failed writing request")
+	}
+
+	w.Header().Set(backupStatusTrailer, backupSuccessful)
+}

--- a/pkg/sidecar/appclone_fakeserver_test.go
+++ b/pkg/sidecar/appclone_fakeserver_test.go
@@ -129,7 +129,7 @@ func (fSrv *fakeServer) backupHandler(w http.ResponseWriter, req *http.Request) 
 
 	// Error: return http status code of 500
 	if fSrv.simulateError {
-		http.Error(w, "xtrbackup failed", http.StatusInternalServerError)
+		http.Error(w, "xtrabackup failed", http.StatusInternalServerError)
 		return
 	}
 

--- a/pkg/sidecar/appclone_test.go
+++ b/pkg/sidecar/appclone_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"sigs.k8s.io/testing_frameworks/integration/addr"
 )
 
 var _ = Describe("Test RunCloneCommand cloning logic", func() {
@@ -36,10 +37,19 @@ var _ = Describe("Test RunCloneCommand cloning logic", func() {
 		// Normally, these are true k8s services, each listening on
 		// SidecarServerPort. Since we can't simulate that in unit tests, we put
 		// each "service" on its own port.
-		masterServiceAddr          = fmt.Sprintf(":%d", serverPort)
-		healthyReplicasServiceAddr = ":8081"
+
+		masterServiceAddr          string
+		healthyReplicasServiceAddr string
 		skipTruncatedDataTests     = false
 	)
+
+	generateAddress := func() string {
+		port, host, err := addr.Suggest()
+		if err != nil {
+			panic("couldn't generate local address for fakeserver")
+		}
+		return fmt.Sprintf("%s:%d", host, port)
+	}
 
 	setupFakeDataDir := func() {
 		tempDataDir, err := ioutil.TempDir("", "mysql-operator-tests")
@@ -102,9 +112,12 @@ var _ = Describe("Test RunCloneCommand cloning logic", func() {
 	}
 
 	BeforeSuite(func() {
+		masterServiceAddr = generateAddress()
+		healthyReplicasServiceAddr = generateAddress()
+
 		cfg = &Config{
-			masterService:              "localhost" + masterServiceAddr,
-			healthyReplicaCloneService: "localhost" + healthyReplicasServiceAddr,
+			masterService:              masterServiceAddr,
+			healthyReplicaCloneService: healthyReplicasServiceAddr,
 		}
 
 		setupFakeDataDir()

--- a/pkg/sidecar/appclone_test.go
+++ b/pkg/sidecar/appclone_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 Harvest
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package sidecar
 
 import (

--- a/pkg/sidecar/appclone_test.go
+++ b/pkg/sidecar/appclone_test.go
@@ -191,7 +191,7 @@ var _ = Describe("Test RunCloneCommand cloning logic", func() {
 			Expect(fakeReplicaServer.backupRequestsReceived()).To(Equal(1))
 			Expect(fakeMasterServer.backupRequestsReceived()).To(Equal(0))
 
-			expectBackupFileToBeCreated()
+			Expect(fakeBackupFile).ShouldNot(BeAnExistingFile())
 		})
 
 	})

--- a/pkg/sidecar/appclone_test.go
+++ b/pkg/sidecar/appclone_test.go
@@ -1,0 +1,226 @@
+package sidecar
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"io/ioutil"
+	"os"
+	"path"
+)
+
+var _ = Describe("Test RunCloneCommand cloning logic", func() {
+
+	var (
+		cfg               *Config
+		fakeBackupFile    string // as named in fakeServer.validXBStream
+		fakeMasterServer  *fakeServer
+		fakeReplicaServer *fakeServer
+		// Normally, these are true k8s services, each listening on
+		// SidecarServerPort. Since we can't simulate that in unit tests, we put
+		// each "service" on its own port.
+		masterServiceAddr          = fmt.Sprintf(":%d", serverPort)
+		healthyReplicasServiceAddr = ":8081"
+	)
+
+	setupFakeDataDir := func() {
+		tempDataDir, err := ioutil.TempDir("", "mysql-operator-tests")
+		Expect(err).ToNot(HaveOccurred())
+		dataDir = tempDataDir
+		fakeBackupFile = path.Join(dataDir, "t")
+	}
+
+	teardownFakeDataDir := func() {
+		err := os.RemoveAll(dataDir)
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	startFakeServer := func(address string) *fakeServer {
+		fakeSrv := newFakeServer(address, cfg)
+		err := fakeSrv.start()
+		Expect(err).NotTo(HaveOccurred())
+		return fakeSrv
+	}
+
+	startFakeMasterService := func() {
+		fakeMasterServer = startFakeServer(masterServiceAddr)
+	}
+
+	startFakeReplicaService := func() {
+		fakeReplicaServer = startFakeServer(healthyReplicasServiceAddr)
+	}
+
+	stopFakeMasterService := func() {
+		if fakeMasterServer != nil {
+			err := fakeMasterServer.stop()
+			Expect(err).ToNot(HaveOccurred())
+		}
+	}
+
+	stopFakeReplicaService := func() {
+		if fakeReplicaServer != nil {
+			err := fakeReplicaServer.stop()
+			Expect(err).ToNot(HaveOccurred())
+		}
+	}
+
+	// Don't let xtrabackup try to --prepare our little fake xbstream sample or
+	// it will return errors.
+	disableXtraBackup := func() {
+		xtrabackupCommand = "echo"
+	}
+
+	BeforeSuite(func() {
+		cfg = &Config{
+			masterService:              "localhost" + masterServiceAddr,
+			healthyReplicaCloneService: "localhost" + healthyReplicasServiceAddr,
+		}
+
+		setupFakeDataDir()
+		disableXtraBackup()
+	})
+
+	AfterSuite(func() {
+		teardownFakeDataDir()
+	})
+
+	BeforeEach(func() {
+		err := os.RemoveAll(fakeBackupFile)
+		Expect(err).ToNot(HaveOccurred())
+		cfg.ExistsMySQLData = false
+		startFakeReplicaService()
+		startFakeMasterService()
+	})
+
+	AfterEach(func() {
+		stopFakeMasterService()
+		stopFakeReplicaService()
+	})
+
+	It("should not try to clone when data already exists", func() {
+		cfg.ExistsMySQLData = true
+
+		err := RunCloneCommand(cfg)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(fakeReplicaServer.backupRequestsReceived()).To(Equal(0))
+		Expect(fakeMasterServer.backupRequestsReceived()).To(Equal(0))
+
+		Expect(fakeBackupFile).ShouldNot(BeAnExistingFile())
+	})
+
+	It("should request a backup and succeed ", func() {
+		Expect(fakeBackupFile).ShouldNot(BeAnExistingFile())
+
+		err := RunCloneCommand(cfg)
+		Expect(err).To(Succeed())
+
+		Expect(fakeReplicaServer.backupRequestsReceived()).To(Equal(1))
+		Expect(fakeMasterServer.backupRequestsReceived()).To(Equal(0))
+
+		Expect(fakeBackupFile).Should(BeAnExistingFile())
+	})
+
+	Context("with truncated xbstream data from replicas", func() {
+
+		BeforeEach(func() {
+			fakeReplicaServer.simulateTruncate = true
+		})
+
+		It("cloneFromSource should clean up the data directory after failure", func() {
+			Expect(fakeBackupFile).ShouldNot(BeAnExistingFile())
+
+			err := cloneFromSource(cfg, healthyReplicasServiceAddr)
+			Expect(err).To(HaveOccurred())
+
+			Expect(fakeReplicaServer.backupRequestsReceived()).To(Equal(1))
+			Expect(fakeMasterServer.backupRequestsReceived()).To(Equal(0))
+
+			Expect(fakeBackupFile).ShouldNot(BeAnExistingFile())
+		})
+
+		It("should not fall back to master service", func() {
+			Expect(fakeBackupFile).ShouldNot(BeAnExistingFile())
+
+			err := RunCloneCommand(cfg)
+			Expect(err).To(HaveOccurred())
+
+			Expect(fakeReplicaServer.backupRequestsReceived()).To(Equal(1))
+			Expect(fakeMasterServer.backupRequestsReceived()).To(Equal(0))
+
+			Expect(fakeBackupFile).ShouldNot(BeAnExistingFile())
+		})
+
+	})
+
+	Context("with http error during backup", func() {
+
+		BeforeEach(func() {
+			fakeReplicaServer.simulateError = true
+		})
+
+		It("cloneFromSource should clean up the data directory after failure", func() {
+			Expect(fakeBackupFile).ShouldNot(BeAnExistingFile())
+
+			err := cloneFromSource(cfg, healthyReplicasServiceAddr)
+			Expect(err).To(HaveOccurred())
+
+			Expect(fakeReplicaServer.backupRequestsReceived()).To(Equal(1))
+			Expect(fakeMasterServer.backupRequestsReceived()).To(Equal(0))
+
+			Expect(fakeBackupFile).ShouldNot(BeAnExistingFile())
+		})
+
+		It("should not fall back to master service", func() {
+			Expect(fakeBackupFile).ShouldNot(BeAnExistingFile())
+
+			err := RunCloneCommand(cfg)
+			Expect(err).To(HaveOccurred())
+
+			Expect(fakeReplicaServer.backupRequestsReceived()).To(Equal(1))
+			Expect(fakeMasterServer.backupRequestsReceived()).To(Equal(0))
+
+			Expect(fakeBackupFile).ShouldNot(BeAnExistingFile())
+		})
+
+	})
+
+	Context("with no healthy replicas service", func() {
+
+		BeforeEach(func() {
+			stopFakeReplicaService()
+		})
+
+		It("should fall back to master service and succeed", func() {
+			Expect(fakeBackupFile).ShouldNot(BeAnExistingFile())
+
+			err := RunCloneCommand(cfg)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(fakeReplicaServer.backupRequestsReceived()).To(Equal(0))
+			Expect(fakeMasterServer.backupRequestsReceived()).To(Equal(1))
+
+			Expect(fakeBackupFile).Should(BeAnExistingFile())
+		})
+
+	})
+
+	Context("with no healthy replicas or master service", func() {
+
+		BeforeEach(func() {
+			stopFakeReplicaService()
+			stopFakeMasterService()
+		})
+
+		It("should return nil", func() {
+			Expect(fakeBackupFile).ShouldNot(BeAnExistingFile())
+
+			err := RunCloneCommand(cfg)
+			Expect(err).To(Succeed())
+
+			Expect(fakeBackupFile).ShouldNot(BeAnExistingFile())
+		})
+
+	})
+
+})

--- a/pkg/sidecar/appclone_test.go
+++ b/pkg/sidecar/appclone_test.go
@@ -255,11 +255,22 @@ var _ = Describe("Test RunCloneCommand cloning logic", func() {
 			stopFakeMasterService()
 		})
 
-		It("should return nil", func() {
+		It("should return nil for first pod", func() {
+			cfg.Hostname = "mysql-mysql-0"
 			Expect(fakeBackupFile).ShouldNot(BeAnExistingFile())
 
 			err := RunCloneCommand(cfg)
 			Expect(err).To(Succeed())
+
+			Expect(fakeBackupFile).ShouldNot(BeAnExistingFile())
+		})
+
+		It("should return an error for subsequent pods", func() {
+			cfg.Hostname = "mysql-mysql-1"
+			Expect(fakeBackupFile).ShouldNot(BeAnExistingFile())
+
+			err := RunCloneCommand(cfg)
+			Expect(err).To(HaveOccurred())
 
 			Expect(fakeBackupFile).ShouldNot(BeAnExistingFile())
 		})

--- a/pkg/sidecar/configs.go
+++ b/pkg/sidecar/configs.go
@@ -75,6 +75,9 @@ type Config struct {
 
 	// Offset for assigning MySQL Server ID
 	MyServerIDOffset int
+
+	masterService              string
+	healthyReplicaCloneService string
 }
 
 // FQDNForServer returns the pod hostname for given MySQL server id
@@ -90,7 +93,18 @@ func (cfg *Config) ClusterFQDN() string {
 
 // MasterFQDN the FQ Name of the cluster's master
 func (cfg *Config) MasterFQDN() string {
+	if cfg.masterService != "" {
+		return cfg.masterService
+	}
 	return mysqlcluster.GetNameForResource(mysqlcluster.MasterService, cfg.ClusterName)
+}
+
+// ReplicasFQDN the FQ Name of the replicas service
+func (cfg *Config) ReplicasFQDN() string {
+	if cfg.healthyReplicaCloneService != "" {
+		return cfg.healthyReplicaCloneService
+	}
+	return mysqlcluster.GetNameForResource(mysqlcluster.HealthyReplicasService, cfg.ClusterName)
 }
 
 // ServerID returns the MySQL server id

--- a/pkg/sidecar/configs.go
+++ b/pkg/sidecar/configs.go
@@ -120,6 +120,7 @@ func (cfg *Config) MysqlDSN() string {
 	)
 }
 
+// IsFirstPodInSet returns true if this pod has an ordinal of 0, meaning it is the first one in the set
 func (cfg *Config) IsFirstPodInSet() bool {
 	ordinal := getOrdinalFromHostname(cfg.Hostname)
 	return ordinal == 0

--- a/pkg/sidecar/configs.go
+++ b/pkg/sidecar/configs.go
@@ -120,6 +120,11 @@ func (cfg *Config) MysqlDSN() string {
 	)
 }
 
+func (cfg *Config) IsFirstPodInSet() bool {
+	ordinal := getOrdinalFromHostname(cfg.Hostname)
+	return ordinal == 0
+}
+
 // ShouldCloneFromBucket returns true if it's time to initialize from a bucket URL provided
 func (cfg *Config) ShouldCloneFromBucket() bool {
 	return !cfg.ExistsMySQLData && cfg.ServerID() == 100 && len(cfg.InitBucketURL) != 0

--- a/pkg/sidecar/constants.go
+++ b/pkg/sidecar/constants.go
@@ -65,6 +65,11 @@ var (
 	serverProbeEndpoint = constants.SidecarServerProbePath
 	// ServerBackupEndpoint is the http server endpoint for backups
 	serverBackupEndpoint = "/xbackup"
+
+	// xtrabackup Executable Name
+	xtrabackupCommand = "xtrabackup"
+	// xbstream Executable Name
+	xbStreamCommand = "xbstream"
 )
 
 const (

--- a/pkg/sidecar/constants.go
+++ b/pkg/sidecar/constants.go
@@ -18,6 +18,7 @@ package sidecar
 
 import (
 	"strconv"
+	"time"
 
 	// add mysql driver
 	_ "github.com/go-sql-driver/mysql"
@@ -65,6 +66,8 @@ var (
 	serverProbeEndpoint = constants.SidecarServerProbePath
 	// ServerBackupEndpoint is the http server endpoint for backups
 	serverBackupEndpoint = "/xbackup"
+	// ServerDialTimeout is the connect timeout (not http timeout) for requesting a backup from the sidecar server
+	serverConnectTimeout = 5 * time.Second
 
 	// xtrabackup Executable Name
 	xtrabackupCommand = "xtrabackup"

--- a/pkg/sidecar/server.go
+++ b/pkg/sidecar/server.go
@@ -19,12 +19,14 @@ package sidecar
 import (
 	"context"
 	"fmt"
+	"github.com/presslabs/mysql-operator/pkg/util/constants"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
-
-	"github.com/presslabs/mysql-operator/pkg/util/constants"
+	"strings"
+	"time"
 )
 
 const (
@@ -90,7 +92,7 @@ func (s *server) backupHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Trailer", backupStatusTrailer)
 
 	// nolint: gosec
-	xtrabackup := exec.Command("xtrabackup", "--backup", "--slave-info", "--stream=xbstream",
+	xtrabackup := exec.Command(xtrabackupCommand, "--backup", "--slave-info", "--stream=xbstream",
 		fmt.Sprintf("--tables-exclude=%s.%s", constants.OperatorDbName, constants.OperatorStatusTableName),
 		"--host=127.0.0.1", fmt.Sprintf("--user=%s", s.cfg.ReplicationUser),
 		fmt.Sprintf("--password=%s", s.cfg.ReplicationPassword),
@@ -151,13 +153,33 @@ func maxClients(h http.Handler, n int) http.Handler {
 	})
 }
 
+func prepareUrl(svc string, endpoint string) string {
+	if !strings.Contains(svc, ":") {
+		svc = fmt.Sprintf("%s:%d", svc, serverPort)
+	}
+	return fmt.Sprintf("http://%s%s", svc, endpoint)
+}
+
+func fastTimeoutTransport(dialTimeout int) http.RoundTripper {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   time.Duration(dialTimeout) * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+}
+
 // requestABackup connects to specified host and endpoint and gets the backup
 func requestABackup(cfg *Config, host, endpoint string) (*http.Response, error) {
 	log.Info("initialize a backup", "host", host, "endpoint", endpoint)
 
-	req, err := http.NewRequest("GET", fmt.Sprintf(
-		"http://%s:%d%s", host, serverPort, endpoint), nil)
-
+	req, err := http.NewRequest("GET", prepareUrl(host, endpoint), nil)
 	if err != nil {
 		return nil, fmt.Errorf("fail to create request: %s", err)
 	}
@@ -166,6 +188,7 @@ func requestABackup(cfg *Config, host, endpoint string) (*http.Response, error) 
 	req.SetBasicAuth(cfg.BackupUser, cfg.BackupPassword)
 
 	client := &http.Client{}
+	client.Transport = fastTimeoutTransport(5)
 
 	resp, err := client.Do(req)
 	if err != nil || resp.StatusCode != 200 {

--- a/pkg/sidecar/server.go
+++ b/pkg/sidecar/server.go
@@ -160,11 +160,11 @@ func prepareURL(svc string, endpoint string) string {
 	return fmt.Sprintf("http://%s%s", svc, endpoint)
 }
 
-func fastTimeoutTransport(dialTimeout int) http.RoundTripper {
+func transportWithTimeout(connectTimeout time.Duration) http.RoundTripper {
 	return &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
-			Timeout:   time.Duration(dialTimeout) * time.Second,
+			Timeout:   connectTimeout,
 			KeepAlive: 30 * time.Second,
 			DualStack: true,
 		}).DialContext,
@@ -188,7 +188,7 @@ func requestABackup(cfg *Config, host, endpoint string) (*http.Response, error) 
 	req.SetBasicAuth(cfg.BackupUser, cfg.BackupPassword)
 
 	client := &http.Client{}
-	client.Transport = fastTimeoutTransport(5)
+	client.Transport = transportWithTimeout(serverConnectTimeout)
 
 	resp, err := client.Do(req)
 	if err != nil || resp.StatusCode != 200 {

--- a/pkg/sidecar/server.go
+++ b/pkg/sidecar/server.go
@@ -153,7 +153,7 @@ func maxClients(h http.Handler, n int) http.Handler {
 	})
 }
 
-func prepareUrl(svc string, endpoint string) string {
+func prepareURL(svc string, endpoint string) string {
 	if !strings.Contains(svc, ":") {
 		svc = fmt.Sprintf("%s:%d", svc, serverPort)
 	}
@@ -179,7 +179,7 @@ func fastTimeoutTransport(dialTimeout int) http.RoundTripper {
 func requestABackup(cfg *Config, host, endpoint string) (*http.Response, error) {
 	log.Info("initialize a backup", "host", host, "endpoint", endpoint)
 
-	req, err := http.NewRequest("GET", prepareUrl(host, endpoint), nil)
+	req, err := http.NewRequest("GET", prepareURL(host, endpoint), nil)
 	if err != nil {
 		return nil, fmt.Errorf("fail to create request: %s", err)
 	}

--- a/test/e2e/cluster/cluster.go
+++ b/test/e2e/cluster/cluster.go
@@ -147,7 +147,7 @@ var _ = Describe("Mysql cluster tests", func() {
 
 		// delete PVC from master pod and wait for it to be removed
 		pvcName := "data-" + podName
-		deletePVCSynchronously(f, pvcName, cluster.Namespace, 15 * time.Second)
+		deletePVCSynchronously(f, pvcName, cluster.Namespace, 30*time.Second)
 
 		// now delete master pod
 		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(podName, &meta.DeleteOptions{})


### PR DESCRIPTION
This PR is an attempt to make the cloning process, especially during/after failover, more resilient by using k8s services to locate a source to clone from.

## The Problem
The issue that sparked this is https://github.com/presslabs/mysql-operator/issues/412. In short, if you delete the master's PVC and delete the master pod, then the master will never be re-cloned and can never re-join the cluster.

## Solution: Clone From a Service
Our solution is based on the idea that we could just use k8s services to point to the sidecar backup service on the master and on healthy replicas. To do that, we simply added the `SidecarServerPort` to the existing master service. We had to add one new service, [`HealthyReplicasSVC`](https://github.com/dougfales/mysql-operator/blob/use-services-for-cloning/pkg/controller/mysqlcluster/internal/syncer/healthy_replicas_service.go), to point to healthy *replicas only* (excluding the master).

The logic for cloning then becomes:

1. Try to clone [from the healthy replica service](https://github.com/dougfales/mysql-operator/blob/use-services-for-cloning/pkg/sidecar/appclone.go#L68).
2. If that service appears unavailable, try cloning [from the master service](https://github.com/dougfales/mysql-operator/blob/use-services-for-cloning/pkg/sidecar/appclone.go#L73).
3. If that service is also unavailable, try cloning [from the init bucket url](https://github.com/dougfales/mysql-operator/blob/use-services-for-cloning/pkg/sidecar/appclone.go#L79).
4. If there is no init bucket, return [without cloning](https://github.com/dougfales/mysql-operator/blob/use-services-for-cloning/pkg/sidecar/appclone.go#L84) (as will happen when creating a new empty cluster).

If during the course of these attempts there is an error, we return with the error immediately. This causes the `clone-and-init` command to `exit(1)`, which results in the pod initialization being retried later by k8s. This "fail fast" approach is intentional; we did not want to embed a bunch of retry logic in this function when k8s is already there to try again in a much more visible way.

## Tests

We created an e2e test case which demonstrates the failure described in the issue [here](https://github.com/dougfales/mysql-operator/blob/use-services-for-cloning/test/e2e/cluster/cluster.go#L131-L167).

We have also [added unit tests for the functionality in `RunCloneCommand`](https://github.com/dougfales/mysql-operator/blob/use-services-for-cloning/pkg/sidecar/appclone_test.go). These tests rely on a mock backup server, defined in [`appclone_fakeserver_test.go`](https://github.com/dougfales/mysql-operator/blob/use-services-for-cloning/pkg/sidecar/appclone_fakeserver_test.go). This mock server runs on [two separate ports](https://github.com/dougfales/mysql-operator/blob/use-services-for-cloning/pkg/sidecar/appclone_test.go#L22-L23) because that was the simplest way we could think of to emulate two separate k8s services in a unit test environment.

## Caveats/Questions

We are still testing this approach ourselves, but so far it fixes the original issue and seems not to cause any new ones.

However, looking at the cloning logic has raised a few questions for us about what the operator *should* do in some cases. For instance:

1. If for some reason both replica and master services are temporarily unavailable, and the cluster has an init bucket URL, we will clone from that bucket. This may not always make sense, e.g. if someone has a very old init bucket URL. This might be something to consider for future documentation or improvement.

2. It seems possible that, at a specific point during a failover, the healthy replica service could be empty while the master service is not (the window is small, but it could happen). In that case, is it acceptable that this code would fall back to the master service, putting extra strain on the master from `xtrabackup`? We think this acceptable for now, but I'd like to make this scenario less likely in the future.

3. If these services were unavailable and there is no init bucket URL configured, an empty replica might be initialized when what we really wanted was a cloned replica. This replica would then likely fail to replicate from the master, and I assume it would be killed and recreated eventually by the operator. This is probably a scenario to cover with an e2e test case eventually.

## Notes

I will attempt to leave some comments throughout the code as some of the changes are much clearer in context.

Thanks again for considering this PR @AMecea. Please let us know if you want any changes or if you think there's a better way to go about this solution.

Thanks to @stankevich and @eik3 for helping put this together.
