### PR TITLE
Make backupScheduleJobsHistoryLimit configurable in mysql-cluster chart

### DIFF
--- a/charts/mysql-cluster/Chart.yaml
+++ b/charts/mysql-cluster/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for easy deployment of a MySQL cluster with MySQL operator.
 name: mysql-cluster
-version: 0.1.2
+version: 0.2.0

--- a/charts/mysql-cluster/templates/cluster.yaml
+++ b/charts/mysql-cluster/templates/cluster.yaml
@@ -28,6 +28,9 @@ spec:
   backupRemoteDeletePolicy: {{ .Values.backupRemoteDeletePolicy }}
   backupURL: {{ required ".mysql.backupURL is missing" .Values.backupURL }}
   {{- end }}
+  {{- if .Values.backupScheduleJobsHistoryLimit }}
+  backupScheduleJobsHistoryLimit: {{ .Values.backupScheduleJobsHistoryLimit }}
+  {{- end }}
 
   {{- if .Values.mysqlConf }}
   mysqlConf:

--- a/charts/mysql-cluster/values.yaml
+++ b/charts/mysql-cluster/values.yaml
@@ -18,6 +18,7 @@ volumeSpec:
 serverIDOffset:
 
 backupSchedule:
+backupScheduleJobsHistoryLimit:
 backupURL:
 backupSecretName:
 backupRemoteDeletePolicy:


### PR DESCRIPTION
This makes the backupScheduleJobsHistoryLimit field of the MysqlCluster resource configurable in mysql-cluster helm chart.