### PR TITLE
Backup restore fixes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -203,7 +203,7 @@ pipeline:
       event: push
 
   e2e-tests:
-    image: quay.io/presslabs/bfc
+    image: quay.io/presslabs/bfc:0.1
     secrets:
       - GOOGLE_CREDENTIALS
     environment:

--- a/pkg/controller/orchestrator/orchestrator_reconcile_test.go
+++ b/pkg/controller/orchestrator/orchestrator_reconcile_test.go
@@ -314,6 +314,29 @@ var _ = Describe("Orchestrator reconciler", func() {
 			Expect(master).To(BeNil())
 
 		})
+		It("should be unable to find a clear master even if the CoMaster is not set by orchestrator", func() {
+			// Topology:
+			//  0
+			//  |
+			//  1
+			orcClient.AddInstance(orc.Instance{
+				ClusterName: cluster.GetClusterAlias(),
+				Key:         orc.InstanceKey{Hostname: cluster.GetPodHostname(0)},
+				MasterKey:   orc.InstanceKey{Hostname: cluster.GetPodHostname(1)},
+			})
+			orcClient.AddInstance(orc.Instance{
+				ClusterName: cluster.GetClusterAlias(),
+				Key:         orc.InstanceKey{Hostname: cluster.GetPodHostname(1)},
+				MasterKey:   orc.InstanceKey{Hostname: cluster.GetPodHostname(0)},
+			})
+
+			var insts InstancesSet
+			insts, _ = orcClient.Cluster(cluster.GetClusterAlias())
+
+			// should not determine any master because there are two masters
+			master := insts.DetermineMaster()
+			Expect(master).To(BeNil())
+		})
 	})
 
 	It("should not determine the master when master is not in orc", func() {

--- a/pkg/sidecar/appconf.go
+++ b/pkg/sidecar/appconf.go
@@ -185,6 +185,7 @@ func initFileQuery(cfg *Config, gtidPurged string) []byte {
 	// create the status table used by the operator to configure or to mask MySQL node ready
 	// CSV engine for this table can't be used because we use REPLACE statement that requires PRIMARY KEY or
 	// UNIQUE KEY index
+	// NOTE: value column should be big enough to contain all GTIDs from xtrabackup_slave_info file
 	// nolint: gosec
 	queries = append(queries, fmt.Sprintf(
 		"CREATE TABLE IF NOT EXISTS %[1]s.%[2]s ("+

--- a/pkg/sidecar/configs.go
+++ b/pkg/sidecar/configs.go
@@ -108,7 +108,7 @@ func (cfg *Config) MysqlDSN() string {
 
 // ShouldCloneFromBucket returns true if it's time to initialize from a bucket URL provided
 func (cfg *Config) ShouldCloneFromBucket() bool {
-	return !cfg.ExistsMySQLData && cfg.ServerID() == 100 && len(cfg.InitBucketURL) != 0
+	return !cfg.ExistsMySQLData && cfg.ServerID() == cfg.MyServerIDOffset && len(cfg.InitBucketURL) != 0
 }
 
 // NewConfig returns a pointer to Config configured from environment variables


### PR DESCRIPTION
 * Uses the custom offset when deciding to clone from a bucket
 * Prevent to follow infinite loops if orchestrator doesn't set `CoMaster` to `true`