### PR TITLE
Parameterize metrics collector args

### DIFF
--- a/config/crds/mysql_v1alpha1_mysqlcluster.yaml
+++ b/config/crds/mysql_v1alpha1_mysqlcluster.yaml
@@ -84,6 +84,13 @@ spec:
                 is removed from service.
               format: int64
               type: integer
+            metricsExporterExtraArgs:
+              description: MetricsExporterExtraArgs is a list of extra command line
+                arguments to pass to MySQL metrics exporter. See https://github.com/prometheus/mysqld_exporter
+                for the list of available flags.
+              items:
+                type: string
+              type: array
             minAvailable:
               description: The number of pods from that set that must still be available
                 after the eviction, even in the absence of the evicted pod Defaults

--- a/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
+++ b/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
@@ -123,6 +123,11 @@ type MysqlClusterSpec struct {
 	// Set a custom offset for Server IDs.  ServerID for each node will be the index of the statefulset, plus offset
 	// +optional
 	ServerIDOffset *int `json:"serverIDOffset,omitempty"`
+
+	// MetricsExporterExtraArgs is a list of extra command line arguments to pass to MySQL metrics exporter.
+	// See https://github.com/prometheus/mysqld_exporter for the list of available flags.
+	// +optional
+	MetricsExporterExtraArgs []string `json:"metricsExporterExtraArgs,omitempty"`
 }
 
 // MysqlConf defines type for extra cluster configs. It's a simple map between

--- a/pkg/apis/mysql/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/mysql/v1alpha1/zz_generated.deepcopy.go
@@ -257,6 +257,11 @@ func (in *MysqlClusterSpec) DeepCopyInto(out *MysqlClusterSpec) {
 		*out = new(int)
 		**out = **in
 	}
+	if in.MetricsExporterExtraArgs != nil {
+		in, out := &in.MetricsExporterExtraArgs, &out.MetricsExporterExtraArgs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
+++ b/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
@@ -333,15 +333,22 @@ func (s *sfsSyncer) ensureContainersSpec() []core.Container {
 	})
 
 	// METRICS container
+	exporterCommand := []string{
+		fmt.Sprintf("--web.listen-address=0.0.0.0:%d", ExporterPort),
+		fmt.Sprintf("--web.telemetry-path=%s", ExporterPath),
+		"--collect.heartbeat",
+		fmt.Sprintf("--collect.heartbeat.database=%s", constants.OperatorDbName),
+	}
+
+	if len(s.cluster.Spec.MetricsExporterExtraArgs) > 0 {
+		exporterCommand = append(exporterCommand, s.cluster.Spec.MetricsExporterExtraArgs...)
+	}
+
 	exporter := s.ensureContainer(containerExporterName,
 		s.opt.MetricsExporterImage,
-		[]string{
-			fmt.Sprintf("--web.listen-address=0.0.0.0:%d", ExporterPort),
-			fmt.Sprintf("--web.telemetry-path=%s", ExporterPath),
-			"--collect.heartbeat",
-			fmt.Sprintf("--collect.heartbeat.database=%s", constants.OperatorDbName),
-		},
+		exporterCommand,
 	)
+
 	exporter.Ports = ensurePorts(core.ContainerPort{
 		Name:          ExporterPortName,
 		ContainerPort: ExporterPort,


### PR DESCRIPTION
Allows passing extra args to the metrics exporter via the cluster spec to e.g. enable/configure additional metrics collectors.

Example:

```yaml
---
apiVersion: mysql.presslabs.org/v1alpha1
kind: MysqlCluster
metadata:
  name: example
spec:
  # [...]
  metricsExporterExtraArgs:
    - --collect.info_schema.userstats
    - --collect.perf_schema.file_events
  # [...]
```