### PR TITLE
Parameterize xbstream args

### DIFF
--- a/config/crds/mysql_v1alpha1_mysqlcluster.yaml
+++ b/config/crds/mysql_v1alpha1_mysqlcluster.yaml
@@ -223,6 +223,12 @@ spec:
                     by HostPath and EmptyDir. And represents the PVC specification.
                   type: object
               type: object
+            xbstreamExtraArgs:
+              description: XbstreamExtraArgs is a list of extra command line arguments
+                to pass to xbstream.
+              items:
+                type: string
+              type: array
           required:
           - secretName
           type: object

--- a/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
+++ b/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
@@ -133,6 +133,10 @@ type MysqlClusterSpec struct {
 	// See https://github.com/prometheus/mysqld_exporter for the list of available flags.
 	// +optional
 	MetricsExporterExtraArgs []string `json:"metricsExporterExtraArgs,omitempty"`
+
+	// XbstreamExtraArgs is a list of extra command line arguments to pass to xbstream.
+	// +optional
+	XbstreamExtraArgs []string `json:"xbstreamExtraArgs,omitempty"`
 }
 
 // MysqlConf defines type for extra cluster configs. It's a simple map between

--- a/pkg/apis/mysql/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/mysql/v1alpha1/zz_generated.deepcopy.go
@@ -267,6 +267,11 @@ func (in *MysqlClusterSpec) DeepCopyInto(out *MysqlClusterSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.XbstreamExtraArgs != nil {
+		in, out := &in.XbstreamExtraArgs, &out.XbstreamExtraArgs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
+++ b/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
@@ -170,6 +170,7 @@ func (s *sfsSyncer) envVarFromSecret(sctName, name, key string, opt bool) core.E
 	return env
 }
 
+// nolint: gocyclo
 func (s *sfsSyncer) getEnvFor(name string) []core.EnvVar {
 	env := []core.EnvVar{}
 

--- a/pkg/sidecar/appclone_fakeserver_test.go
+++ b/pkg/sidecar/appclone_fakeserver_test.go
@@ -34,7 +34,7 @@ type fakeServer struct {
 	calls            []loggedRequest
 	simulateTruncate bool // Will cause the next request to truncate the response
 	simulateError    bool // Will cause the next request to return http error
-	validXBStream    []byte
+	validXbstream    []byte
 }
 
 func newFakeServer(address string, cfg *Config) *fakeServer {
@@ -47,8 +47,8 @@ func newFakeServer(address string, cfg *Config) *fakeServer {
 		},
 	}
 
-	// A small file named "t" containing the text "fake-backup", encoded with xbstream -c
-	fSrv.validXBStream = []byte{
+	// A small file named "t" containing the text "fake-backup", encoded with `xbstream --create`
+	fSrv.validXbstream = []byte{
 		0x58, 0x42, 0x53, 0x54, 0x43, 0x4b, 0x30, 0x31, 0x00, 0x50, 0x01, 0x00, 0x00, 0x00, 0x74, 0x0c, // XBSTCK01.P....t.
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x6b, // ...............k
 		0xcc, 0x84, 0x00, 0x66, 0x61, 0x6b, 0x65, 0x2d, 0x62, 0x61, 0x63, 0x6b, 0x75, 0x70, 0x0a, 0x58, // ...fake-backup.X
@@ -137,10 +137,10 @@ func (fSrv *fakeServer) backupHandler(w http.ResponseWriter, req *http.Request) 
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("Trailer", backupStatusTrailer)
 
-	backup := fSrv.validXBStream
+	backup := fSrv.validXbstream
 	// Truncate: send half the stream, with "successful" trailers
 	if fSrv.simulateTruncate {
-		backup = fSrv.validXBStream[0:10]
+		backup = fSrv.validXbstream[0:10]
 	}
 
 	if _, err := w.Write(backup); err != nil {

--- a/pkg/sidecar/appclone_test.go
+++ b/pkg/sidecar/appclone_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Test RunCloneCommand cloning logic", func() {
 
 	var (
 		cfg               *Config
-		fakeBackupFile    string // as named in fakeServer.validXBStream
+		fakeBackupFile    string // as named in fakeServer.validXbstream
 		fakeMasterServer  *fakeServer
 		fakeReplicaServer *fakeServer
 		// Normally, these are true k8s services, each listening on
@@ -98,9 +98,9 @@ var _ = Describe("Test RunCloneCommand cloning logic", func() {
 		xtrabackupCommand = "echo"
 	}
 
-	disableXbStreamIfNotAvailable := func() {
-		if _, err := exec.LookPath(xbStreamCommand); err != nil {
-			xbStreamCommand = "echo"
+	disableXbstreamIfNotAvailable := func() {
+		if _, err := exec.LookPath(xbstreamCommand); err != nil {
+			xbstreamCommand = "echo"
 			skipTruncatedDataTests = true
 		}
 	}
@@ -122,7 +122,7 @@ var _ = Describe("Test RunCloneCommand cloning logic", func() {
 
 		setupFakeDataDir()
 		disableXtraBackup()
-		disableXbStreamIfNotAvailable()
+		disableXbstreamIfNotAvailable()
 	})
 
 	AfterSuite(func() {

--- a/pkg/sidecar/constants.go
+++ b/pkg/sidecar/constants.go
@@ -71,8 +71,9 @@ var (
 
 	// xtrabackup Executable Name
 	xtrabackupCommand = "xtrabackup"
+
 	// xbstream Executable Name
-	xbStreamCommand = "xbstream"
+	xbstreamCommand = "xbstream"
 )
 
 const (


### PR DESCRIPTION
This is a reissue of https://github.com/presslabs/mysql-operator/pull/469. I made a few attempts in simplifying and breaking `getEnvFor` into smaller pieces to avoid the lint issues but didn't come up with a satisfactory result without refactoring a large portion of the whole `statefullset.go`. I'll leave this for another day 😜. For now, I'm disabling the cyclomatic complexity check on `getEnvFor`.

Picking up from @dougfales, re: https://github.com/presslabs/mysql-operator/issues/437.

Allows passing extra args to `xbstream` via the cluster spec to e.g. increase the number of threads.

Example:

```yaml
---
apiVersion: mysql.presslabs.org/v1alpha1
kind: MysqlCluster
metadata:
  name: example
spec:
  # [...]
  xbstreamExtraArgs:
    - --parallel=8
  # [...]
```

Went through the code and normalized the `xbstream` references (there were `xbstream`, `Xbstream`, `xbStream`, and `XbStream`).