### PR TITLE
document that the cron format takes a 6th argument for seconds

### DIFF
--- a/docs/cluster-recurrent-backups.md
+++ b/docs/cluster-recurrent-backups.md
@@ -17,7 +17,7 @@ To be able to store backups, the secret defined under `backupBucketSecretName` m
 
 You need to set the `backupBucketURL` in the cluster spec as an URL like `s3://BUCKET_NAME`, and the secret with storage credentials (`backupSecretName`).
 
-See the example below to configure a cluster that has recurrent backups that runs once per day at midnight. To schedule a backup set `backupSchedule` field that is under crontab format. For more details about CRON format can be found [here](https://godoc.org/github.com/robfig/cron).
+See the example below to configure a cluster that has recurrent backups that runs once per day at midnight. To schedule a backup set `backupSchedule` field that is under crontab format. For more details about CRON format can be found [here](https://godoc.org/github.com/robfig/cron). Keep in mind this CRON format takes a 6th argument for seconds.
 
 ``` yaml
 apiVersion: mysql.presslabs.org/v1alpha1
@@ -33,12 +33,12 @@ spec:
   backupRemoteDeletePolicy: retain|delete
 ```
 
-Some crontab examples and their predefined schedulers:
+Crontab takes 6 arguments from the traditional 5. The additional argument is a seconds field. Some crontab examples and their predefined schedulers:
 
 | Entry         | Equivalent To          | Description                                |
 | ------------- | -----                  | -----------                                |
-| 0 0 0 1 1 *   | @yearly (or @annually) | Run once a year, midnight, Jan. 1st        |
-| 0 0 0 1 * *   | @monthly               | Run once a month, midnight, first of month |
-| 0 0 0 * * 0   | @weekly                | Run once a week, midnight between Sat/Sun  |
-| 0 0 0 * * *   | @daily (or @midnight)  | Run once a day, midnight                   |
-| 0 0 * * * *   | @hourly                | Run once an hour, beginning of hour        |
+| 15 0 0 1 1 *  | @yearly (or @annually) | Run once a year, midnight, Jan. 1st, 15th second        |
+| 0 0 0 1 * *   | @monthly               | Run once a month, midnight, first of month, 0 second |
+| 0 0 0 * * 0   | @weekly                | Run once a week, midnight between Sat/Sun, 0 second  |
+| 0 0 0 * * *   | @daily (or @midnight)  | Run once a day, midnight, 0 second, 0 second                   |
+| 0 0 * * * *   | @hourly                | Run once an hour, beginning of hour, 0 second        |

--- a/docs/deploy-mysql-cluster.md
+++ b/docs/deploy-mysql-cluster.md
@@ -79,20 +79,20 @@ $ kubectl apply -f example-cluster.yaml
 
 Some important fields of `MySQLCluster` resource from `spec` are described in the following table:
 
-| Field Name                       | Description                                                                              | Example                    | Default value           |
-| ---                              | ---                                                                                      | ---                        | ---                     |
-| `replicas`                       | The cluster replicas, how many nodes to deploy.                                          | 2                          | 1 (a single node)       |
-| `secretName`                     | The name of the credentials secret. Should be in the same namespace with the cluster.    | `my-secret`                | *is required*           |
-| `backupSchedule`                 | Represents the time and frequency of making cluster backups, in a cron format.           | `0 0 * * *`                | ""                      |
-| `backupURL`                      | The bucket URL where to put the backup.                                                  | `gs://bucket/app`          | ""                      |
-| `backupSecretName`               | The name of the secret that contains credentials for connecting to the storage provider. | `backups-secret`           | ""                      |
-| `backupScheduleJobsHistoryLimit` | The number of many backups to keep.                                                      | `10`                       | inf                     |
-| `mysqlConf`                      | Key-value configs for MySQL that will be set in `my.cnf` under `mysqld` section.         | `max_allowed_packet: 128M` | {}                      |
-| `podSpec`                        | This allows to specify pod-related configs. (e.g. `imagePullSecrets`, `labels` )         |                            | {}                      |
-| `volumeSpec`                     | Specifications for PVC, HostPath or EmptyDir, used to store data.                        |                            | (a PVC with size = 1GB) |
-| `maxSlaveLatency`                | The allowed slave lag until it's removed from read service. (in seconds)                 | `30`                       | nil                     |
-| `queryLimits`                    | Parameters for pt-kill to ensure some query run limits. (e.g. idle time)                 | `idelTime: 60`             | nil                     |
-| `readOnly`                       | A Boolean value that sets the cluster in read-only state.                                | `True`                     | False                   |
+| Field Name                       | Description                                                                                 | Example                    | Default value           |
+| ---                              | ---                                                                                         | ---                        | ---                     |
+| `replicas`                       | The cluster replicas, how many nodes to deploy.                                             | 2                          | 1 (a single node)       |
+| `secretName`                     | The name of the credentials secret. Should be in the same namespace with the cluster.       | `my-secret`                | *is required*           |
+| `backupSchedule`                 | Represents the time and frequency of making cluster backups, in a cron format with seconds. | `0 0 0 * * *`              | ""                      |
+| `backupURL`                      | The bucket URL where to put the backup.                                                     | `gs://bucket/app`          | ""                      |
+| `backupSecretName`               | The name of the secret that contains credentials for connecting to the storage provider.    | `backups-secret`           | ""                      |
+| `backupScheduleJobsHistoryLimit` | The number of many backups to keep.                                                         | `10`                       | inf                     |
+| `mysqlConf`                      | Key-value configs for MySQL that will be set in `my.cnf` under `mysqld` section.            | `max_allowed_packet: 128M` | {}                      |
+| `podSpec`                        | This allows to specify pod-related configs. (e.g. `imagePullSecrets`, `labels` )            |                            | {}                      |
+| `volumeSpec`                     | Specifications for PVC, HostPath or EmptyDir, used to store data.                           |                            | (a PVC with size = 1GB) |
+| `maxSlaveLatency`                | The allowed slave lag until it's removed from read service. (in seconds)                    | `30`                       | nil                     |
+| `queryLimits`                    | Parameters for pt-kill to ensure some query run limits. (e.g. idle time)                    | `idelTime: 60`             | nil                     |
+| `readOnly`                       | A Boolean value that sets the cluster in read-only state.                                   | `True`                     | False                   |
 
 
 For more detailed information about cluster structure and configuration fields can be found in [godoc](https://godoc.org/github.com/presslabs/mysql-operator/pkg/apis/mysql/v1alpha1#MysqlClusterSpec).

--- a/examples/example-cluster-init.yaml
+++ b/examples/example-cluster-init.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 2
   secretName: the-secret
 
-  backupSchedule: "1 1 * * *"
+  backupSchedule: "0 1 1 * * *"
   backupURL: gs://bucket_name/path/
   backupSecretName: backup-secret
 

--- a/examples/example-cluster.yaml
+++ b/examples/example-cluster.yaml
@@ -12,7 +12,7 @@ spec:
   ## PodDisruptionBudget
   # minAvailable: 1
 
-  ## For recurrent backups set backupSchedule with a cronjob expression
+  ## For recurrent backups set backupSchedule with a cronjob expression with seconds
   # backupSchedule:
   # backupURL: s3://bucket_name/
   # backupSecretName:

--- a/pkg/controller/mysqlbackupcron/mysqlbackupcron_controller_test.go
+++ b/pkg/controller/mysqlbackupcron/mysqlbackupcron_controller_test.go
@@ -101,7 +101,7 @@ var _ = Describe("MysqlBackupCron controller", func() {
 				Replicas:   &two,
 				SecretName: "a-secret",
 
-				BackupSchedule:   "0 0 0 * *",
+				BackupSchedule:   "0 0 0 0 * *",
 				BackupSecretName: "a-backup-secret",
 				BackupURL:        "gs://bucket/",
 			},
@@ -141,7 +141,7 @@ var _ = Describe("MysqlBackupCron controller", func() {
 
 		It("should update cluster backup schedule", func() {
 			// update cluster scheduler
-			cluster.Spec.BackupSchedule = "0 0 * * *"
+			cluster.Spec.BackupSchedule = "0 0 0 * * *"
 			newSchedule, _ := cronpkg.Parse(cluster.Spec.BackupSchedule)
 			Expect(c.Update(context.TODO(), cluster)).To(Succeed())
 


### PR DESCRIPTION
ran into an issue with the documentation showing a cron format of 5 arguments, but the cron scheduler being used takes in a 6th argument for seconds. while testing, my backups were running every second instead of the intended every minute.