### PR TITLE
Fall back to current master pod for backup candidate

### DIFF
--- a/pkg/controller/mysqlbackup/internal/syncer/job.go
+++ b/pkg/controller/mysqlbackup/internal/syncer/job.go
@@ -110,7 +110,7 @@ func (s *jobSyncer) getBackupCandidate() string {
 		}
 	}
 
-	log.Info("no healthy slave node found so returns the master node", "default_node", s.cluster.GetMasterHost(),
+	log.Info("no healthy slave node found so returns the master node", "master_node", s.cluster.GetMasterHost(),
 		"cluster", s.cluster)
 	return s.cluster.GetMasterHost()
 }

--- a/pkg/controller/mysqlbackup/internal/syncer/job.go
+++ b/pkg/controller/mysqlbackup/internal/syncer/job.go
@@ -109,9 +109,10 @@ func (s *jobSyncer) getBackupCandidate() string {
 			return node.Name
 		}
 	}
-	log.Info("no healthy slave node found so returns the master node", "default_node", s.cluster.GetPodHostname(0),
+
+	log.Info("no healthy slave node found so returns the master node", "default_node", s.cluster.GetMasterHost(),
 		"cluster", s.cluster)
-	return s.cluster.GetPodHostname(0)
+	return s.cluster.GetMasterHost()
 }
 
 func (s *jobSyncer) ensurePodSpec(in core.PodSpec) core.PodSpec {

--- a/pkg/controller/mysqlbackup/internal/syncer/job_test.go
+++ b/pkg/controller/mysqlbackup/internal/syncer/job_test.go
@@ -86,7 +86,7 @@ var _ = Describe("MysqlBackup job syncer", func() {
 		Expect(syncer.getBackupCandidate()).To(Equal(cluster.GetPodHostname(1)))
 	})
 
-	It("should return the master if replicas is not healthy", func() {
+	It("should return the master if replicas are not healthy", func() {
 		cluster.Status.Nodes = []api.NodeStatus{
 			api.NodeStatus{
 				Name:       cluster.GetPodHostname(0),
@@ -98,5 +98,19 @@ var _ = Describe("MysqlBackup job syncer", func() {
 			},
 		}
 		Expect(syncer.getBackupCandidate()).To(Equal(cluster.GetPodHostname(0)))
+	})
+
+	It("should return the master if replicas are not healthy, even when master is not pod 0", func() {
+		cluster.Status.Nodes = []api.NodeStatus{
+			api.NodeStatus{
+				Name:       cluster.GetPodHostname(0),
+				Conditions: testutil.NodeConditions(false, false, false, true),
+			},
+			api.NodeStatus{
+				Name:       cluster.GetPodHostname(1),
+				Conditions: testutil.NodeConditions(true, false, false, false),
+			},
+		}
+		Expect(syncer.getBackupCandidate()).To(Equal(cluster.GetPodHostname(1)))
 	})
 })


### PR DESCRIPTION
Hi @AMecea and @yoichiwo7, this is intended to fix https://github.com/presslabs/mysql-operator/issues/475 by using the `GetMasterHost()` function to return the current master rather than just returning pod 0. 

All unit tests pass for me, including one new one added for this specific case.

Thanks @stankevich for the heads up about this and for reviewing.