### PR TITLE
Parameterize xtrabackup and rclone args

### DIFF
--- a/config/crds/mysql_v1alpha1_mysqlcluster.yaml
+++ b/config/crds/mysql_v1alpha1_mysqlcluster.yaml
@@ -229,6 +229,22 @@ spec:
               items:
                 type: string
               type: array
+            xtrabackupExtraArgs:
+              description: XtrabackupExtraArgs is a list of extra command line arguments
+                to pass to xtrabackup.
+              items:
+                type: string
+              type: array
+            xtrabackupPrepareExtraArgs:
+              description: XtrabackupPrepareExtraArgs is a list of extra command line
+                arguments to pass to xtrabackup during --prepare.
+              items:
+                type: string
+              type: array
+            xtrabackupTargetDir:
+              description: XtrabackupTargetDir is a backup destination directory for
+                xtrabackup.
+              type: string
           required:
           - secretName
           type: object

--- a/config/crds/mysql_v1alpha1_mysqlcluster.yaml
+++ b/config/crds/mysql_v1alpha1_mysqlcluster.yaml
@@ -179,6 +179,12 @@ spec:
               required:
               - maxQueryTime
               type: object
+            rcloneExtraArgs:
+              description: RcloneExtraArgs is a list of extra command line arguments
+                to pass to rclone.
+              items:
+                type: string
+              type: array
             readOnly:
               description: Makes the cluster READ ONLY. Set the master to writable
                 or ReadOnly

--- a/examples/example-cluster.yaml
+++ b/examples/example-cluster.yaml
@@ -88,3 +88,18 @@ spec:
   # metricsExporterExtraArgs:
   #   - --collect.info_schema.userstats
   #   - --collect.perf_schema.file_events
+
+  ## Add extra arguments to xbstream
+  # xbstreamExtraArgs:
+  #   - --parallel=8
+
+  ## Add extra arguments to xtrabackup
+  # xtrabackupExtraArgs:
+  #   - --parallel=8
+
+  ## Add extra arguments to xtrabackup during --prepare
+  # xtrabackupPrepareExtraArgs:
+  #   - --use-memory=5G
+
+  ## Set xtrabackup target directory
+  # xtrabackupTargetDir: /var/lib/mysql/.tmp/xtrabackup/

--- a/examples/example-cluster.yaml
+++ b/examples/example-cluster.yaml
@@ -89,6 +89,14 @@ spec:
   #   - --collect.info_schema.userstats
   #   - --collect.perf_schema.file_events
 
+  ## Add extra arguments to rclone
+  # rcloneExtraArgs:
+  #   - --buffer-size=1G
+  #   - --multi-thread-streams=8
+  #   - --retries-sleep=10s
+  #   - --retries=10
+  #   - --transfers=8
+
   ## Add extra arguments to xbstream
   # xbstreamExtraArgs:
   #   - --parallel=8
@@ -101,5 +109,5 @@ spec:
   # xtrabackupPrepareExtraArgs:
   #   - --use-memory=5G
 
-  ## Set xtrabackup target directory
+  ## Set xtrabackup target directory (the directory needs to exist)
   # xtrabackupTargetDir: /var/lib/mysql/.tmp/xtrabackup/

--- a/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
+++ b/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
@@ -134,6 +134,10 @@ type MysqlClusterSpec struct {
 	// +optional
 	MetricsExporterExtraArgs []string `json:"metricsExporterExtraArgs,omitempty"`
 
+	// RcloneExtraArgs is a list of extra command line arguments to pass to rclone.
+	// +optional
+	RcloneExtraArgs []string `json:"rcloneExtraArgs,omitempty"`
+
 	// XbstreamExtraArgs is a list of extra command line arguments to pass to xbstream.
 	// +optional
 	XbstreamExtraArgs []string `json:"xbstreamExtraArgs,omitempty"`

--- a/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
+++ b/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
@@ -137,6 +137,19 @@ type MysqlClusterSpec struct {
 	// XbstreamExtraArgs is a list of extra command line arguments to pass to xbstream.
 	// +optional
 	XbstreamExtraArgs []string `json:"xbstreamExtraArgs,omitempty"`
+
+	// XtrabackupExtraArgs is a list of extra command line arguments to pass to xtrabackup.
+	// +optional
+	XtrabackupExtraArgs []string `json:"xtrabackupExtraArgs,omitempty"`
+
+	// XtrabackupPrepareExtraArgs is a list of extra command line arguments to pass to xtrabackup
+	// during --prepare.
+	// +optional
+	XtrabackupPrepareExtraArgs []string `json:"xtrabackupPrepareExtraArgs,omitempty"`
+
+	// XtrabackupTargetDir is a backup destination directory for xtrabackup.
+	// +optional
+	XtrabackupTargetDir string `json:"xtrabackupTargetDir,omitempty"`
 }
 
 // MysqlConf defines type for extra cluster configs. It's a simple map between

--- a/pkg/apis/mysql/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/mysql/v1alpha1/zz_generated.deepcopy.go
@@ -267,6 +267,11 @@ func (in *MysqlClusterSpec) DeepCopyInto(out *MysqlClusterSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.RcloneExtraArgs != nil {
+		in, out := &in.RcloneExtraArgs, &out.RcloneExtraArgs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.XbstreamExtraArgs != nil {
 		in, out := &in.XbstreamExtraArgs, &out.XbstreamExtraArgs
 		*out = make([]string, len(*in))

--- a/pkg/apis/mysql/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/mysql/v1alpha1/zz_generated.deepcopy.go
@@ -272,6 +272,16 @@ func (in *MysqlClusterSpec) DeepCopyInto(out *MysqlClusterSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.XtrabackupExtraArgs != nil {
+		in, out := &in.XtrabackupExtraArgs, &out.XtrabackupExtraArgs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.XtrabackupPrepareExtraArgs != nil {
+		in, out := &in.XtrabackupPrepareExtraArgs, &out.XtrabackupPrepareExtraArgs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
+++ b/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
@@ -18,9 +18,10 @@ package mysqlcluster
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"strconv"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/imdario/mergo"
 	apps "k8s.io/api/apps/v1"
@@ -233,6 +234,30 @@ func (s *sfsSyncer) getEnvFor(name string) []core.EnvVar {
 		env = append(env, core.EnvVar{
 			Name:  "XBSTREAM_EXTRA_ARGS",
 			Value: strings.Join(s.cluster.Spec.XbstreamExtraArgs, " "),
+		})
+	}
+
+	hasXtrabackupExtraArgs := len(s.cluster.Spec.XtrabackupExtraArgs) > 0
+	if hasXtrabackupExtraArgs && isSidecar(name) {
+		env = append(env, core.EnvVar{
+			Name:  "XTRABACKUP_EXTRA_ARGS",
+			Value: strings.Join(s.cluster.Spec.XtrabackupExtraArgs, " "),
+		})
+	}
+
+	hasXtrabackupPrepareExtraArgs := len(s.cluster.Spec.XtrabackupPrepareExtraArgs) > 0
+	if hasXtrabackupPrepareExtraArgs && isCloneAndInit(name) {
+		env = append(env, core.EnvVar{
+			Name:  "XTRABACKUP_PREPARE_EXTRA_ARGS",
+			Value: strings.Join(s.cluster.Spec.XtrabackupPrepareExtraArgs, " "),
+		})
+	}
+
+	hasXtrabackupTargetDir := len(s.cluster.Spec.XtrabackupTargetDir) > 0
+	if hasXtrabackupTargetDir && isSidecar(name) {
+		env = append(env, core.EnvVar{
+			Name:  "XTRABACKUP_TARGET_DIR",
+			Value: s.cluster.Spec.XtrabackupTargetDir,
 		})
 	}
 

--- a/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
+++ b/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
@@ -229,6 +229,14 @@ func (s *sfsSyncer) getEnvFor(name string) []core.EnvVar {
 		})
 	}
 
+	hasRcloneExtraArgs := len(s.cluster.Spec.RcloneExtraArgs) > 0
+	if hasRcloneExtraArgs && (isCloneAndInit(name) || isSidecar(name)) {
+		env = append(env, core.EnvVar{
+			Name:  "RCLONE_EXTRA_ARGS",
+			Value: strings.Join(s.cluster.Spec.RcloneExtraArgs, " "),
+		})
+	}
+
 	hasXbstreamExtraArgs := len(s.cluster.Spec.XbstreamExtraArgs) > 0
 	if hasXbstreamExtraArgs && (isCloneAndInit(name) || isSidecar(name)) {
 		env = append(env, core.EnvVar{

--- a/pkg/internal/mysqlcluster/defaults.go
+++ b/pkg/internal/mysqlcluster/defaults.go
@@ -104,6 +104,11 @@ func (cluster *MysqlCluster) SetDefaults(opt *options.Options) {
 			setConfigIfNotSet(cluster.Spec.MysqlConf, "binlog-space-limit", humanizeSize(binlogSpaceLimit))
 		}
 	}
+
+	// set default xtrabackup target directory
+	if len(cluster.Spec.XtrabackupTargetDir) == 0 {
+		cluster.Spec.XtrabackupTargetDir = "/tmp/xtrabackup_backupfiles/"
+	}
 }
 
 func setConfigIfNotSet(conf api.MysqlConf, option string, value intstr.IntOrString) {

--- a/pkg/sidecar/appclone.go
+++ b/pkg/sidecar/appclone.go
@@ -91,7 +91,11 @@ func RunCloneCommand(cfg *Config) error {
 	}
 
 	// prepare backup
-	return xtrabackupPrepareData()
+	if err := xtrabackupPrepare(cfg); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func isServiceAvailable(svc string) bool {
@@ -228,14 +232,12 @@ func cloneFromSource(cfg *Config, host string) error {
 	return nil
 }
 
-func xtrabackupPrepareData() error {
+func xtrabackupPrepare(cfg *Config) error {
 	// nolint: gosec
-	xtbkCmd := exec.Command(xtrabackupCommand, "--prepare",
-		fmt.Sprintf("--target-dir=%s", dataDir))
+	xtrabackupPrepare := exec.Command(xtrabackupCommand, cfg.XtrabackupPrepareArgs()...)
+	xtrabackupPrepare.Stderr = os.Stderr
 
-	xtbkCmd.Stderr = os.Stderr
-
-	return xtbkCmd.Run()
+	return xtrabackupPrepare.Run()
 }
 
 func deleteLostFound() error {

--- a/pkg/sidecar/appclone.go
+++ b/pkg/sidecar/appclone.go
@@ -24,6 +24,8 @@ import (
 	"os/exec"
 	"path"
 	"strings"
+
+	"github.com/presslabs/mysql-operator/pkg/util/constants"
 )
 
 // RunCloneCommand clones the data from several potential sources.
@@ -91,11 +93,7 @@ func RunCloneCommand(cfg *Config) error {
 	}
 
 	// prepare backup
-	if err := xtrabackupPrepare(cfg); err != nil {
-		return err
-	}
-
-	return nil
+	return xtrabackupPrepare(cfg)
 }
 
 func isServiceAvailable(svc string) bool {
@@ -134,14 +132,14 @@ func cloneFromBucket(cfg *Config) error {
 
 	log.Info("cloning from bucket", "bucket", initBucket)
 
-	if _, err := os.Stat(rcloneConfigFile); os.IsNotExist(err) {
+	if _, err := os.Stat(constants.RcloneConfigFile); os.IsNotExist(err) {
 		log.Error(err, "rclone config file does not exists")
 		return err
 	}
-	// rclone --config={conf file} cat {bucket uri}
-	// writes to stdout the content of the bucket uri
+
+	// writes the contents of the bucket url to stdout
 	// nolint: gosec
-	rclone := exec.Command("rclone", "-vv", rcloneConfigArg, "cat", initBucket)
+	rclone := exec.Command("rclone", append(cfg.RcloneArgs(), "cat", initBucket)...)
 
 	// gzip reads from stdin decompress and then writes to stdout
 	// nolint: gosec

--- a/pkg/sidecar/appclone_test.go
+++ b/pkg/sidecar/appclone_test.go
@@ -18,12 +18,13 @@ package sidecar
 
 import (
 	"fmt"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"sigs.k8s.io/testing_frameworks/integration/addr"
 )
 
@@ -94,7 +95,7 @@ var _ = Describe("Test RunCloneCommand cloning logic", func() {
 
 	// Don't let xtrabackup try to --prepare our little fake xbstream sample or
 	// it will return errors.
-	disableXtraBackup := func() {
+	disableXtrabackup := func() {
 		xtrabackupCommand = "echo"
 	}
 
@@ -121,7 +122,7 @@ var _ = Describe("Test RunCloneCommand cloning logic", func() {
 		}
 
 		setupFakeDataDir()
-		disableXtraBackup()
+		disableXtrabackup()
 		disableXbstreamIfNotAvailable()
 	})
 

--- a/pkg/sidecar/appconf.go
+++ b/pkg/sidecar/appconf.go
@@ -62,7 +62,7 @@ func RunConfigCommand(cfg *Config) error {
 	gtidPurged, err = readPurgedGTID()
 	if err != nil {
 		// not a fatal error, log it and continue
-		log.Info("error while reading PURGE GTID from xtrabackup info file", "error", err)
+		log.Info("error while reading PURGE GTID from xtrabackup_binlog_info", "error", err)
 	}
 
 	initFilePath := path.Join(confDPath, "operator-init.sql")

--- a/pkg/sidecar/apptakebackup.go
+++ b/pkg/sidecar/apptakebackup.go
@@ -42,7 +42,7 @@ func pushBackupFromTo(cfg *Config, srcHost, destBucket string) error {
 	gzip := exec.Command("gzip", "-c")
 
 	// nolint: gosec
-	rclone := exec.Command("rclone", rcloneConfigArg, "rcat", tmpDestBucket)
+	rclone := exec.Command("rclone", append(cfg.RcloneArgs(), "rcat", tmpDestBucket)...)
 
 	gzip.Stdin = response.Body
 	gzip.Stderr = os.Stderr
@@ -82,13 +82,13 @@ func pushBackupFromTo(cfg *Config, srcHost, destBucket string) error {
 	// the backup was a success
 	// remove .tmp extension
 	// nolint: gosec
-	rcMove := exec.Command("rclone", rcloneConfigArg, "moveto", tmpDestBucket, destBucket)
+	rclone = exec.Command("rclone", append(cfg.RcloneArgs(), "moveto", tmpDestBucket, destBucket)...)
 
-	if err = rcMove.Start(); err != nil {
+	if err = rclone.Start(); err != nil {
 		return fmt.Errorf("final move failed: %s", err)
 	}
 
-	if err = rcMove.Wait(); err != nil {
+	if err = rclone.Wait(); err != nil {
 		return fmt.Errorf("final move failed: %s", err)
 	}
 

--- a/pkg/sidecar/configs.go
+++ b/pkg/sidecar/configs.go
@@ -77,6 +77,9 @@ type Config struct {
 	// Offset for assigning MySQL Server ID
 	MyServerIDOffset int
 
+	// RcloneExtraArgs is a list of extra command line arguments to pass to rclone.
+	RcloneExtraArgs []string
+
 	// XbstreamExtraArgs is a list of extra command line arguments to pass to xbstream.
 	XbstreamExtraArgs []string
 
@@ -143,6 +146,13 @@ func (cfg *Config) IsFirstPodInSet() bool {
 // ShouldCloneFromBucket returns true if it's time to initialize from a bucket URL provided
 func (cfg *Config) ShouldCloneFromBucket() bool {
 	return !cfg.ExistsMySQLData && cfg.ServerID() == cfg.MyServerIDOffset && len(cfg.InitBucketURL) != 0
+}
+
+// RcloneArgs returns a complete set of rclone arguments.
+func (cfg *Config) RcloneArgs() []string {
+	// rclone --config=<config-file> <extra-args>
+	rcloneArgs := []string{fmt.Sprintf("--config=%s", constants.RcloneConfigFile)}
+	return append(rcloneArgs, cfg.RcloneExtraArgs...)
 }
 
 // XbstreamArgs returns a complete set of xbstream arguments.
@@ -232,6 +242,7 @@ func NewConfig() *Config {
 
 		MyServerIDOffset: offset,
 
+		RcloneExtraArgs:            strings.Fields(getEnvValue("RCLONE_EXTRA_ARGS")),
 		XbstreamExtraArgs:          strings.Fields(getEnvValue("XBSTREAM_EXTRA_ARGS")),
 		XtrabackupExtraArgs:        strings.Fields(getEnvValue("XTRABACKUP_EXTRA_ARGS")),
 		XtrabackupPrepareExtraArgs: strings.Fields(getEnvValue("XTRABACKUP_PREPARE_EXTRA_ARGS")),

--- a/pkg/sidecar/constants.go
+++ b/pkg/sidecar/constants.go
@@ -75,11 +75,3 @@ var (
 	// xbstream Executable Name
 	xbstreamCommand = "xbstream"
 )
-
-const (
-	// RcloneConfigFile represents the path to the file that contains rclone
-	// configs. This path should be the same as defined in docker entrypoint
-	// script from mysql-operator-sidecar/docker-entrypoint.sh. /tmp/rclone.conf
-	rcloneConfigFile = constants.RcloneConfigFile
-	rcloneConfigArg  = constants.RcloneConfigArg
-)

--- a/pkg/sidecar/server.go
+++ b/pkg/sidecar/server.go
@@ -19,7 +19,6 @@ package sidecar
 import (
 	"context"
 	"fmt"
-	"github.com/presslabs/mysql-operator/pkg/util/constants"
 	"io"
 	"net"
 	"net/http"
@@ -92,12 +91,7 @@ func (s *server) backupHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Trailer", backupStatusTrailer)
 
 	// nolint: gosec
-	xtrabackup := exec.Command(xtrabackupCommand, "--backup", "--slave-info", "--stream=xbstream",
-		fmt.Sprintf("--tables-exclude=%s.%s", constants.OperatorDbName, constants.OperatorStatusTableName),
-		"--host=127.0.0.1", fmt.Sprintf("--user=%s", s.cfg.ReplicationUser),
-		fmt.Sprintf("--password=%s", s.cfg.ReplicationPassword),
-		"--target-dir=/tmp/xtrabackup_backupfiles/")
-
+	xtrabackup := exec.Command(xtrabackupCommand, s.cfg.XtrabackupArgs()...)
 	xtrabackup.Stderr = os.Stderr
 
 	stdout, err := xtrabackup.StdoutPipe()

--- a/pkg/util/constants/constants.go
+++ b/pkg/util/constants/constants.go
@@ -74,9 +74,6 @@ const (
 	// configs. This path should be the same as defined in docker entrypoint
 	// script from mysql-operator-sidecar/docker-entrypoint.sh. /tmp/rclone.conf
 	RcloneConfigFile = "/tmp/rclone.conf"
-
-	// RcloneConfigArg represents the config argument to rclone cmd
-	RcloneConfigArg = "--config=" + RcloneConfigFile
 )
 
 var (


### PR DESCRIPTION
Allows passing extra args to `xtrabackup` and `rclone` via the cluster spec. Combined with [`xbstreamExtraArgs`](https://github.com/presslabs/mysql-operator/pull/476), these can drastically reduce the time it takes to back up and restore larger datasets (multiple hundreds of GBs) and speed up the scaling events.

`xtrabackupTargetDir` provides an option for configuring a custom backup directory if the default `/tmp/xtrabackup_backupfiles/` is too small or too slow.

```yaml
---
apiVersion: mysql.presslabs.org/v1alpha1
kind: MysqlCluster
metadata:
  name: example
spec:
  # [...]
  rcloneExtraArgs:
    - --buffer-size=1G
    - --multi-thread-streams=8
    - --retries-sleep=10s
    - --retries=10
    - --transfers=8

  xbstreamExtraArgs:
    - --parallel=8

  xtrabackupExtraArgs:
    - --parallel=8

  xtrabackupPrepareExtraArgs:
    - --use-memory=5G

  xtrabackupTargetDir: /var/lib/mysql/.tmp/xtrabackup/
  # [...]
```

Thanks @dougfales for reviewing! Closes https://github.com/presslabs/mysql-operator/issues/437.