### PR TITLE
Support disabling of the ReadOnly cluster setting 

### DIFF
--- a/config/crds/mysql_v1alpha1_mysqlcluster.yaml
+++ b/config/crds/mysql_v1alpha1_mysqlcluster.yaml
@@ -190,7 +190,7 @@ spec:
             readOnly:
               description: Makes the cluster READ ONLY. Set the master to writable
                 or ReadOnly
-              type: boolean
+              type: string
             replicas:
               description: The number of pods. This updates replicas filed Defaults
                 to 0

--- a/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
+++ b/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"strings"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -123,7 +124,7 @@ type MysqlClusterSpec struct {
 
 	// Makes the cluster READ ONLY. Set the master to writable or ReadOnly
 	// +optional
-	ReadOnly bool `json:"readOnly,omitempty"`
+	ReadOnly ReadOnlyMode `json:"readOnly,omitempty"`
 
 	// Set a custom offset for Server IDs.  ServerID for each node will be the index of the statefulset, plus offset
 	// +optional
@@ -299,6 +300,21 @@ const (
 	// NodeConditionReadOnly repesents if the node is read only or not
 	NodeConditionReadOnly NodeConditionType = "ReadOnly"
 )
+
+// +kubebuilder:validation:Enum=true;false;ignored
+type ReadOnlyMode string
+
+const (
+	ReadOnlyControlIgnored ReadOnlyMode = "ignored"
+)
+
+func (rom ReadOnlyMode) IsSet() bool {
+	return strings.EqualFold(string(rom), "true")
+}
+
+func (rom ReadOnlyMode) IsIgnored() bool {
+	return strings.EqualFold(string(rom), string(ReadOnlyControlIgnored))
+}
 
 // MysqlClusterStatus defines the observed state of MysqlCluster
 type MysqlClusterStatus struct {

--- a/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
+++ b/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
@@ -301,17 +301,21 @@ const (
 	NodeConditionReadOnly NodeConditionType = "ReadOnly"
 )
 
+// ReadOnlyMode can be one of "true", "false", or "ignored"
 // +kubebuilder:validation:Enum=true;false;ignored
 type ReadOnlyMode string
 
+// ReadOnlyMode constants
 const (
 	ReadOnlyControlIgnored ReadOnlyMode = "ignored"
 )
 
+// IsSet returns true if cluster ReadOnly setting has been set to true; otherwise it returns false
 func (rom ReadOnlyMode) IsSet() bool {
 	return strings.EqualFold(string(rom), "true")
 }
 
+// IsIgnored returns true if cluster ReadOnly setting is disabled (set to "ignored")
 func (rom ReadOnlyMode) IsIgnored() bool {
 	return strings.EqualFold(string(rom), string(ReadOnlyControlIgnored))
 }

--- a/test/e2e/cluster/cluster.go
+++ b/test/e2e/cluster/cluster.go
@@ -259,7 +259,7 @@ var _ = Describe("Mysql cluster tests", func() {
 
 	It("cluster readOnly", func() {
 		cluster.Spec.Replicas = &two
-		cluster.Spec.ReadOnly = true
+		cluster.Spec.ReadOnly = "true"
 		Expect(f.Client.Update(context.TODO(), cluster)).To(Succeed())
 
 		// test cluster to be ready


### PR DESCRIPTION
Sometimes we have noticed that the management of a cluster's ReadOnly setting can cause unexpected behavior or interfere with what Orchestrator is doing. For instance, we've observed the cluster readonly status flapping between true and false in some cases. I also noticed [this issue](https://github.com/presslabs/mysql-operator/issues/434) which might be related.

Since we would prefer to manage the read/write status manually (via Orchestrator) anyway, we thought we'd try introducing a third option for the [ReadOnly](https://github.com/presslabs/mysql-operator/blob/master/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go#L126) setting, `ignored`, which short-circuits the `markReadOnlyNodesInOrc` function to prevent it from changing anything in Orchestrator. 

@AMecea I'd love to hear your thoughts on this approach.

Thanks to @stankevich for discovering this problem and suggesting this solution. 
