### PR TITLE
Decrease MASTER_CONNECT_RETRY interval

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -43,6 +43,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
  * Change the `mysql-operator` chart to be helm v3 compatible while keeping backward compatibility.
  * Change logging: change `cluster` logging field to `key`; normalize logging and more details;
    output Stackdrive compatible format.
+ * Decrease `MASTER_CONNECT_RETRY` interval from 10 to 1 second.
 ### Removed
 ### Fixed
  * Update and fix e2e tests

--- a/pkg/controller/node/sql.go
+++ b/pkg/controller/node/sql.go
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	// connRetry represents the number of tries to connect to master server
-	connRetry = 10
+	// connRetry specifies the interval between reconnection attempts to master
+	connRetry = 1
 )
 
 // SQLInterface expose abstract operations that can be applied on a MySQL node


### PR DESCRIPTION
Decreases the [`MASTER_CONNECT_RETRY`](https://dev.mysql.com/doc/refman/5.7/en/change-master-to.html) interval from 10 to 1 second to ensure a quicker replication recovery during brief network issues between the replicas and the master.

Related Orchestrator [documentation](https://github.com/openark/orchestrator/blob/3feb95114cec62ef03dce0b31dbb12e06eb046a9/docs/configuration-failure-detection.md#mysql-configuration) recommends doing the same.

---
 - [x] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.
