### PR TITLE
Parameterize the compressor command

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -35,6 +35,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
  * Add `InitContainers` and `Containers` in `.Spec.PodSpec` to allow the user specifying custom containers.
  * Add `MetricsExporterResources` and `MySQLOperatorSidecarResrouces` in `.Spec.PodSpec` to allow
    the user specifying resources for thos sidecars containers.
+ * Add `CompressorCommand` to support any compression/decompression tool as long as it is
+   command-line compatible with `gzip` (example: [`pigz`](https://zlib.net/pigz/)).
 ### Changed
  * [#422](https://github.com/presslabs/mysql-operator/pull/422) adds the `SidecarServerPort` to the
    `MasterService` and introduces one new service, HealthyReplicasService, so that we can try to

--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -45,7 +45,7 @@ RUN useradd -u 999 -r -g 999 -s /sbin/nologin \
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        apt-transport-https ca-certificates wget \
+        apt-transport-https ca-certificates pigz wget \
     && rm -rf /var/lib/apt/lists/*
 
 COPY hack/docker/percona.gpg /etc/apt/trusted.gpg.d/percona.gpg

--- a/config/crds/mysql_v1alpha1_mysqlcluster.yaml
+++ b/config/crds/mysql_v1alpha1_mysqlcluster.yaml
@@ -66,6 +66,10 @@ spec:
             backupURL:
               description: Represents an URL to the location where to put backups.
               type: string
+            compressorCommand:
+              description: CompressorCommand is a compression/decompression tool command-line
+                compatible with gzip.
+              type: string
             image:
               description: To specify the image that will be used for mysql server
                 container. If this is specified then the mysqlVersion is used as source

--- a/examples/example-cluster.yaml
+++ b/examples/example-cluster.yaml
@@ -89,6 +89,9 @@ spec:
   #   - --collect.info_schema.userstats
   #   - --collect.perf_schema.file_events
 
+  ## Use `pigz` (https://zlib.net/pigz) for parallel compression/decompression
+  # compressorCommand: pigz
+
   ## Add extra arguments to rclone
   # rcloneExtraArgs:
   #   - --buffer-size=1G

--- a/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
+++ b/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
@@ -135,6 +135,10 @@ type MysqlClusterSpec struct {
 	// +optional
 	MetricsExporterExtraArgs []string `json:"metricsExporterExtraArgs,omitempty"`
 
+	// CompressorCommand is a compression/decompression tool command-line compatible with gzip.
+	// +optional
+	CompressorCommand string `json:"compressorCommand,omitempty"`
+
 	// RcloneExtraArgs is a list of extra command line arguments to pass to rclone.
 	// +optional
 	RcloneExtraArgs []string `json:"rcloneExtraArgs,omitempty"`

--- a/pkg/controller/mysqlbackup/internal/syncer/job.go
+++ b/pkg/controller/mysqlbackup/internal/syncer/job.go
@@ -169,6 +169,13 @@ func (s *jobSyncer) ensurePodSpec(in core.PodSpec) core.PodSpec {
 		},
 	}
 
+	if len(s.cluster.Spec.CompressorCommand) > 0 {
+		in.Containers[0].Env = append(in.Containers[0].Env, core.EnvVar{
+			Name:  "COMPRESSOR_COMMAND",
+			Value: s.cluster.Spec.CompressorCommand,
+		})
+	}
+
 	if len(s.backup.Spec.BackupSecretName) != 0 {
 		in.Containers[0].EnvFrom = []core.EnvFromSource{
 			core.EnvFromSource{

--- a/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
+++ b/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
@@ -234,6 +234,14 @@ func (s *sfsSyncer) getEnvFor(name string) []core.EnvVar {
 		})
 	}
 
+	hasCompressorCommand := len(s.cluster.Spec.CompressorCommand) > 0
+	if hasCompressorCommand && isCloneAndInit(name) {
+		env = append(env, core.EnvVar{
+			Name:  "COMPRESSOR_COMMAND",
+			Value: s.cluster.Spec.CompressorCommand,
+		})
+	}
+
 	hasRcloneExtraArgs := len(s.cluster.Spec.RcloneExtraArgs) > 0
 	if hasRcloneExtraArgs && (isCloneAndInit(name) || isSidecar(name)) {
 		env = append(env, core.EnvVar{

--- a/pkg/sidecar/apptakebackup.go
+++ b/pkg/sidecar/apptakebackup.go
@@ -39,24 +39,24 @@ func pushBackupFromTo(cfg *Config, srcHost, destBucket string) error {
 	}
 
 	// nolint: gosec
-	gzip := exec.Command("gzip", "-c")
+	compressor := exec.Command(cfg.CompressorCommand(), "-c")
 
 	// nolint: gosec
 	rclone := exec.Command("rclone", append(cfg.RcloneArgs(), "rcat", tmpDestBucket)...)
 
-	gzip.Stdin = response.Body
-	gzip.Stderr = os.Stderr
+	compressor.Stdin = response.Body
+	compressor.Stderr = os.Stderr
 	rclone.Stderr = os.Stderr
 
-	if rclone.Stdin, err = gzip.StdoutPipe(); err != nil {
+	if rclone.Stdin, err = compressor.StdoutPipe(); err != nil {
 		return err
 	}
 
 	errChan := make(chan error, 2)
 
 	go func() {
-		log.V(2).Info("wait for gzip to finish")
-		errChan <- gzip.Run()
+		log.V(2).Info("wait for compressor to finish")
+		errChan <- compressor.Run()
 	}()
 
 	go func() {

--- a/pkg/sidecar/configs.go
+++ b/pkg/sidecar/configs.go
@@ -77,6 +77,9 @@ type Config struct {
 	// Offset for assigning MySQL Server ID
 	MyServerIDOffset int
 
+	// compressorCommand is a compression/decompression tool command-line compatible with gzip.
+	compressorCommand string
+
 	// RcloneExtraArgs is a list of extra command line arguments to pass to rclone.
 	RcloneExtraArgs []string
 
@@ -149,6 +152,14 @@ func (cfg *Config) IsFirstPodInSet() bool {
 // ShouldCloneFromBucket returns true if it's time to initialize from a bucket URL provided
 func (cfg *Config) ShouldCloneFromBucket() bool {
 	return !cfg.ExistsMySQLData && cfg.ServerID() == cfg.MyServerIDOffset && len(cfg.InitBucketURL) != 0
+}
+
+// CompressorCommand returns a command to use for compression/decompression.
+func (cfg *Config) CompressorCommand() string {
+	if cfg.compressorCommand != "" {
+		return cfg.compressorCommand
+	}
+	return "gzip"
 }
 
 // RcloneArgs returns a complete set of rclone arguments.
@@ -245,6 +256,7 @@ func NewConfig() *Config {
 
 		MyServerIDOffset: offset,
 
+		compressorCommand:          getEnvValue("COMPRESSOR_COMMAND"),
 		RcloneExtraArgs:            strings.Fields(getEnvValue("RCLONE_EXTRA_ARGS")),
 		XbstreamExtraArgs:          strings.Fields(getEnvValue("XBSTREAM_EXTRA_ARGS")),
 		XtrabackupExtraArgs:        strings.Fields(getEnvValue("XTRABACKUP_EXTRA_ARGS")),


### PR DESCRIPTION
Allows to use a different compression tool as long as it supports standard gzip command line args (`-c` / `-d`). [`pigz`](https://zlib.net/pigz/) is a safe choice (been using it for a few months now) since it's fully compatible with `gzip` but is much more efficient on larger datasets.

Somewhat related to https://github.com/presslabs/mysql-operator/issues/437.

---
 - [x] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.