### PR TITLE
Fix rclone extra args in the backup job

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 ### Removed
 ### Fixed
+ * rclone extra arguments are now properly passed to the backup job.
 
 
 ## [0.4.0] - TBD
@@ -60,7 +61,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 ### Fixed
  * Update and fix e2e tests
- * Fix double date string in bakup path 
+ * Fix double date string in backup path
  * Copy the nodeSelector as-is in the statefulset (fixes #454)
  * Fix flakines in ReadOnly cluster condition (fixes #434)
  * Fix rounding in computing `innodb-buffer-pool-size` (fixes #501)

--- a/pkg/controller/mysqlbackup/internal/syncer/job.go
+++ b/pkg/controller/mysqlbackup/internal/syncer/job.go
@@ -18,6 +18,7 @@ package syncer
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/presslabs/controller-util/syncer"
 	batch "k8s.io/api/batch/v1"
@@ -167,6 +168,13 @@ func (s *jobSyncer) ensurePodSpec(in core.PodSpec) core.PodSpec {
 				},
 			},
 		},
+	}
+
+	if len(s.cluster.Spec.RcloneExtraArgs) > 0 {
+		in.Containers[0].Env = append(in.Containers[0].Env, core.EnvVar{
+			Name:  "RCLONE_EXTRA_ARGS",
+			Value: strings.Join(s.cluster.Spec.RcloneExtraArgs, " "),
+		})
 	}
 
 	if len(s.backup.Spec.BackupSecretName) != 0 {


### PR DESCRIPTION
I missed this one in presslabs/mysql-operator#486. Without this, rclone in the backup job doesn't get any extra args from the cluster spec.

---
 - [x] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.