### PR TITLE
Set metrics exporter port based on `extra_port`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -59,10 +59,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
  * Change default resource requests/limits for `sidecar` container: requested=10m/32Mi, limit=the same as `.spec.podSpec.resources.limit`
  * Change default resource requests/limits for `exporter` container: requested=10m/32Mi, limit=100m/128Mi
  * Change default resource requests/limits for `heartbeat` container: requested=10m/32Mi, limit=100m/64Mi
+ * If [`extra_port`](https://www.percona.com/doc/percona-server/5.7/performance/threadpool.html#extra_port)
+   is defined in the cluster spec, metrics exporter will use it to connect to MySQL providing that
+   [`extra_max_connections`](https://www.percona.com/doc/percona-server/5.7/performance/threadpool.html#extra_max_connections)
+   is larger than the default `1`. If MySQL server runs out of available connections, using `extra_port`
+   allows the exporter to continue collecting MySQL metrics.
 ### Removed
 ### Fixed
  * Update and fix e2e tests
  * Fix double date string in backup path
+ * Fix double date string in bakup path
  * Copy the nodeSelector as-is in the statefulset (fixes #454)
  * Fix flakines in ReadOnly cluster condition (fixes #434)
  * Fix rounding in computing `innodb-buffer-pool-size` (fixes #501)

--- a/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
+++ b/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
@@ -290,7 +290,7 @@ func (s *sfsSyncer) getEnvFor(name string) []core.EnvVar {
 		env = append(env, s.envVarFromSecret(sctOpName, "PASSWORD", "METRICS_EXPORTER_PASSWORD", false))
 		env = append(env, core.EnvVar{
 			Name:  "DATA_SOURCE_NAME",
-			Value: fmt.Sprintf("$(USER):$(PASSWORD)@(127.0.0.1:%d)/", MysqlPort),
+			Value: fmt.Sprintf("$(USER):$(PASSWORD)@(127.0.0.1:%d)/", s.cluster.ExporterDataSourcePort()),
 		})
 	case containerMySQLInitName:
 		// set MySQL init only flag for init container


### PR DESCRIPTION
If [`extra_port`](https://www.percona.com/doc/percona-server/5.7/performance/threadpool.html#extra_port) (or `extra-port`) is defined in `spec.mysqlConf`, mysqld-exporter should use it instead of the default MySQL port 3306, providing that [`extra_max_connections`](https://www.percona.com/doc/percona-server/5.7/performance/threadpool.html#extra_max_connections) is also set and is larger than the default `1`.

If MySQL server runs out of available connections, using `extra_port` allows the exporter to continue collecting MySQL metrics (which can, potentially, help with troubleshooting the connection issues).

We've been using this for some time now without any issues.

Example:

```yaml
---
apiVersion: mysql.presslabs.org/v1alpha1
kind: MysqlCluster
metadata:
  name: example
spec:
  # [...]
  mysqlConf:
    extra_max_connections: 1000
    extra_port: 3307
  # [...]
```

---
 - [x] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.
