### PR TITLE
Add option to disable read-only/writable setting in operator

### DIFF
--- a/charts/mysql-operator/values.yaml
+++ b/charts/mysql-operator/values.yaml
@@ -139,7 +139,9 @@ orchestrator:
     # Recover both, masters and intermediate masters
     RecoverMasterClusterFilters: ['.*']
     RecoverIntermediateMasterClusterFilters: ['.*']
-    # `reset slave all` and `set read_only=0` on promoted master
+    # `reset slave all` and `set read_only=0` on promoted master; if you use the ignoreReadOnly setting in your mysql
+    # cluster config, then you may want to set this to true, as the operator will not automatically make newly promoted
+    # master instances writable when ignoreReadOnly=true
     ApplyMySQLPromotionAfterMasterFailover: false
     MasterFailoverDetachReplicaMasterHost: true
     # https://github.com/github/orchestrator/blob/master/docs/configuration-recovery.md#promotion-actions

--- a/config/crds/mysql_v1alpha1_mysqlcluster.yaml
+++ b/config/crds/mysql_v1alpha1_mysqlcluster.yaml
@@ -67,7 +67,12 @@ spec:
               description: Represents an URL to the location where to put backups.
               type: string
             ignoreReadOnly:
-              description: Makes the operator ignore the ReadOnly setting completely
+              description: Makes the operator ignore the ReadOnly setting completely.
+                This is an advanced setting that implies you take responsibility for
+                managing the R/W status of your instances. You will need to make sure
+                Orchestrator is configured to set promoted master instances to writable
+                (for example, by setting ApplyMySQLPromotionAfterMasterFailover to
+                true in your Orchestrator configuration).
               type: boolean
             image:
               description: To specify the image that will be used for mysql server

--- a/config/crds/mysql_v1alpha1_mysqlcluster.yaml
+++ b/config/crds/mysql_v1alpha1_mysqlcluster.yaml
@@ -66,6 +66,9 @@ spec:
             backupURL:
               description: Represents an URL to the location where to put backups.
               type: string
+            ignoreReadOnly:
+              description: Makes the operator ignore the ReadOnly setting completely
+              type: boolean
             image:
               description: To specify the image that will be used for mysql server
                 container. If this is specified then the mysqlVersion is used as source

--- a/docs/deploy-mysql-cluster.md
+++ b/docs/deploy-mysql-cluster.md
@@ -93,6 +93,7 @@ Some important fields of `MySQLCluster` resource from `spec` are described in th
 | `maxSlaveLatency`                | The allowed slave lag until it's removed from read service. (in seconds)                    | `30`                       | nil                     |
 | `queryLimits`                    | Parameters for pt-kill to ensure some query run limits. (e.g. idle time)                    | `idelTime: 60`             | nil                     |
 | `readOnly`                       | A Boolean value that sets the cluster in read-only state.                                   | `True`                     | False                   |
+| `ignoreReadOnly`                 | A Boolean value that prevents the operator from changing the R/W status of mysql instances. | `False`                    | False                   |
 
 
 For more detailed information about cluster structure and configuration fields can be found in [godoc](https://godoc.org/github.com/presslabs/mysql-operator/pkg/apis/mysql/v1alpha1#MysqlClusterSpec).

--- a/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
+++ b/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
@@ -126,6 +126,10 @@ type MysqlClusterSpec struct {
 	// +optional
 	ReadOnly bool `json:"readOnly,omitempty"`
 
+	// Makes the operator ignore the ReadOnly setting completely
+	// +optional
+	IgnoreReadOnly bool `json:"ignoreReadOnly,omitempty"`
+
 	// Set a custom offset for Server IDs.  ServerID for each node will be the index of the statefulset, plus offset
 	// +optional
 	ServerIDOffset *int `json:"serverIDOffset,omitempty"`

--- a/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
+++ b/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
@@ -126,7 +126,10 @@ type MysqlClusterSpec struct {
 	// +optional
 	ReadOnly bool `json:"readOnly,omitempty"`
 
-	// Makes the operator ignore the ReadOnly setting completely
+	// Makes the operator ignore the ReadOnly setting completely. This is an advanced setting that implies you take
+	// responsibility for managing the R/W status of your instances. You will need to make sure Orchestrator is configured
+	// to set promoted master instances to writable (for example, by setting ApplyMySQLPromotionAfterMasterFailover to
+	// true in your Orchestrator configuration).
 	// +optional
 	IgnoreReadOnly bool `json:"ignoreReadOnly,omitempty"`
 

--- a/pkg/controller/orchestrator/orchestrator_reconcile.go
+++ b/pkg/controller/orchestrator/orchestrator_reconcile.go
@@ -502,6 +502,14 @@ func (ou *orcUpdater) setReadOnlyNode(inst orc.Instance) error {
 
 // nolint: gocyclo
 func (ou *orcUpdater) markReadOnlyNodesInOrc(insts InstancesSet, master *orc.Instance) {
+	// If the user has set IgnoreReadOnly option to true, we will not interfere with Orchestrator's control of RW status
+	if ou.cluster.Spec.IgnoreReadOnly {
+		if ou.cluster.Spec.ReadOnly {
+			log.Info("IgnoreReadOnly=true takes precedence over ReadOnly=true, will not change RW status of any instances in Orchestrator",
+				"IgnoreReadOnly", ou.cluster.Spec.IgnoreReadOnly, "ReadOnly", ou.cluster.Spec.ReadOnly)
+		}
+		return
+	}
 	// If there is an in-progress failover, we will not interfere with readable/writable status on this iteration.
 	fip := ou.cluster.GetClusterCondition(api.ClusterConditionFailoverInProgress)
 	if fip != nil && fip.Status == core.ConditionTrue {

--- a/pkg/controller/orchestrator/orchestrator_reconcile_test.go
+++ b/pkg/controller/orchestrator/orchestrator_reconcile_test.go
@@ -467,6 +467,23 @@ var _ = Describe("Orchestrator reconciler", func() {
 			Expect(node1.ReadOnly).To(Equal(true))
 		})
 
+		It("should not change read/write status when ReadOnly is Ignored", func() {
+			// Ignore the ReadOnly management; we will never tell Orchestrator what to do in this case
+			cluster.Spec.IgnoreReadOnly = true
+
+			insts, _ := orcClient.Cluster(cluster.GetClusterAlias())
+			node0 := InstancesSet(insts).GetInstance(cluster.GetPodHostname(0))
+
+			node0.ReadOnly = true
+			updater.markReadOnlyNodesInOrc(insts, node0)
+			Expect(node0.ReadOnly).To(Equal(true))
+
+			node0.ReadOnly = false
+			updater.markReadOnlyNodesInOrc(insts, node0)
+			Expect(node0.ReadOnly).To(Equal(false))
+
+		})
+
 		It("should remove old nodes from orchestrator", func() {
 			cluster.Spec.Replicas = &one
 			cluster.Status.ReadyNodes = 1


### PR DESCRIPTION
We would prefer to manage the readable/writable state of mysql instances outside of the operator. On the rare occasion (for us) that the entire cluster must be set to RO, we will do this ourselves. In all other scenarios, we are used to trusting Orchestrator to do the right thing. As @chasebolt alluded to in https://github.com/presslabs/mysql-operator/issues/482, if you set `ApplyMySQLPromotionAfterMasterFailover` to `true` in the Orchestrator config, you can rely on Orchestrator make sure the newly promoted master becomes writable. 

This change allows you to specify `ignoreReadOnly: true` in your cluster settings in order to [bypass](https://github.com/dougfales/mysql-operator/blob/ignore-readonly/pkg/controller/orchestrator/orchestrator_reconcile.go#L506-L512) all of the `setReadOnlyNode`/`setWritableNode` in `markReadOnlyNodesInOrc`. 

Because this setting doesn't make sense without also flipping the `ApplyMySQLPromotionAfterMasterFailover` switch, I've included some [more explanation](https://github.com/dougfales/mysql-operator/blob/ignore-readonly/charts/mysql-operator/values.yaml#L142-L145) by that setting in the operator's `values.yaml`. 

I've also tried to [make it clear](https://github.com/dougfales/mysql-operator/blob/ignore-readonly/config/crds/mysql_v1alpha1_mysqlcluster.yaml#L69-L75) in the spec documentation that this setting is not to be changed without understanding that the burden is then on you, not the operator, to make your cluster writable.

### Other Notes

* This is a less complicated implementation of [my first attempt](https://github.com/presslabs/mysql-operator/pull/498).
* I considered setting the master to writable when bootstrapping the cluster, as seen here: https://github.com/dougfales/mysql-operator/commit/5ab4183d54268855b4eb9eef5ad46181261a212d. After discussing with @stankevich and @eik3, we decided this was too much, and we'd rather set the cluster writable ourselves after the initial deploy. 
* @AMecea I know you [mentioned](https://github.com/presslabs/mysql-operator/pull/498#issuecomment-601622170) that determining of who is master could be affected by this, but I tried to only bypass the *setting* of R/W and not the updating of node status. I think the operator's knowledge of who is master will be unaffected by this change (so far my testing have not shown this to be a problem), but if I'm missing something, please let me know. Thanks!

---
 - [ ] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.
