### PR TITLE
Set timeout of 15s for orchestrator requests

### DIFF
--- a/pkg/controller/mysqlcluster/internal/upgrades/upgrades.go
+++ b/pkg/controller/mysqlcluster/internal/upgrades/upgrades.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
@@ -241,7 +242,7 @@ func NewUpgrader(client client.Client, recorder record.EventRecorder, cluster *m
 		cluster:   cluster,
 		recorder:  recorder,
 		client:    client,
-		orcClient: orc.NewFromURI(opt.OrchestratorURI),
+		orcClient: orc.NewFromURI(opt.OrchestratorURI, 10*time.Second),
 		version:   300,
 	}
 }

--- a/pkg/orchestrator/fake/client.go
+++ b/pkg/orchestrator/fake/client.go
@@ -22,7 +22,6 @@ import (
 	"regexp"
 	"strings"
 	"sync"
-
 	// nolint: golint
 	. "github.com/presslabs/mysql-operator/pkg/orchestrator"
 )
@@ -46,11 +45,6 @@ func getNextID() int64 {
 	nextID = nextID + 1
 	return nextID
 }
-
-const (
-	// NoLag is the constant that sets an instance as no lag
-	NoLag int64 = -1
-)
 
 // New fake orchestrator client
 func New() *OrcFakeClient {

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -18,6 +18,7 @@ package orchestrator
 
 import (
 	"fmt"
+	"time"
 )
 
 // Interface is the orchestrator client interface
@@ -42,12 +43,14 @@ type Interface interface {
 
 type orchestrator struct {
 	connectURI string
+	timeout    time.Duration
 }
 
 // NewFromURI returns the orchestrator client configured to specified uri api endpoint
-func NewFromURI(uri string) Interface {
+func NewFromURI(uri string, timeout time.Duration) Interface {
 	return &orchestrator{
 		connectURI: uri,
+		timeout:    timeout,
 	}
 }
 

--- a/pkg/orchestrator/util.go
+++ b/pkg/orchestrator/util.go
@@ -38,7 +38,9 @@ func (o *orchestrator) makeGetRequest(path string, out interface{}) *Error {
 		return NewErrorMsg(fmt.Sprintf("can't create request: %s", err.Error()), path)
 	}
 
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: o.timeout,
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return NewErrorMsg(err.Error(), path)

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -98,7 +98,7 @@ func (f *Framework) BeforeEach() {
 	}
 
 	By("create a orchestrator client")
-	f.OrcClient = orc.NewFromURI(fmt.Sprintf(orchestratorURITemplate, OrchestratorPort))
+	f.OrcClient = orc.NewFromURI(fmt.Sprintf(orchestratorURITemplate, OrchestratorPort), 10*time.Second)
 
 }
 


### PR DESCRIPTION
We are using a client without a timeout and if the orchestrator blocks it takes to long to respond  (usually because of high load) the worker will get blocked and will not try again.