### PR TITLE
Add ServiceMonitor for prometheus.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.4.0] - TBD
 ### Added
+ * Added a `ServiceMonitor` to the operator chart that scrapes all MySQL instances.
  * Added a test suite for RunCloneCommand logic, along with a mock backup server.
  * Added checks for service availability when cloning.
  * Added "fail fast" logic when unexpected errors occur during cloning/download.

--- a/charts/mysql-operator/templates/servicemonitor.yaml
+++ b/charts/mysql-operator/templates/servicemonitor.yaml
@@ -1,0 +1,30 @@
+# This is a ServicMonitor for the MySQL clusters, not the operator itself.
+# To scrape the operator, we need https://github.com/presslabs/mysql-operator/issues/151 first.
+{{ if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" -}}{{ if .Values.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "mysql-operator.fullname" . }}
+  labels:
+    {{- include "mysql-operator.labels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.additionalLabels }}
+    {{ toYaml .Values.serviceMonitor.additionalLabels }}
+    {{- end }}
+spec:
+  {{- if .Values.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.serviceMonitor.jobLabel }}
+  {{- end }}
+  {{- if .Values.serviceMonitor.targetLabels }}
+  targetLabels: {{ .Values.serviceMonitor.targetLabels }}
+  {{- end }}
+  {{- if .Values.serviceMonitor.podTargetLabels }}
+  podTargetLabels: {{ .Values.serivceMonitor.podTargetLabels }}
+  {{- end }}
+  endpoints:
+    - interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      port: prometheus
+      path: /metrics
+  namespaceSelector: {{ toYaml .Values.serviceMonitor.namespaceSelector | nindent 4 }}
+  selector: {{ toYaml .Values.serviceMonitor.selector | nindent 4 }}
+{{ end -}}{{ end -}}

--- a/charts/mysql-operator/values.yaml
+++ b/charts/mysql-operator/values.yaml
@@ -12,6 +12,24 @@ installCRDs: true
 # in which namespace to watch for resource, leave empty to watch in all namespaces
 watchNamespace:
 
+# The operator will install a ServiceMonitor if you have prometheus-operator installed.
+serviceMonitor:
+  enabled: true
+  ## Additional labels for the serviceMonitor. Useful if you have multiple prometheus operators running to select only specific ServiceMonitors
+  # additionalLabels:
+  #   prometheus: prom-internal
+  interval: 10s
+  scrapeTimeout: 3s
+  # jobLabel:
+  # targetLabels:
+  # podTargetLabels:
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: mysql.presslabs.org
+      app.kubernetes.io/name: mysql
+
 nodeSelector: {}
 tolerations: []
 resources: {}


### PR DESCRIPTION
This commit adds a ServiceMonitor that is deployed when the CRD exists.
Fixes #214.

---
 - [x] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.
