### PR TITLE
orchestrator: increase ConditionUnknown timeout

### DIFF
--- a/pkg/controller/orchestrator/orchestrator_reconcile.go
+++ b/pkg/controller/orchestrator/orchestrator_reconcile.go
@@ -208,8 +208,11 @@ func (ou *orcUpdater) updateNodesStatus(insts InstancesSet, master *orc.Instance
 		host := node.Key.Hostname
 
 		// nodes that are not up to date in orchestrator should be marked as unknown
-		if !node.IsUpToDate {
+		if !node.IsRecentlyChecked {
+			log.V(1).Info("Orchestrator detected host as stale", "host", host)
+
 			if !node.IsLastCheckValid {
+				log.V(1).Info("Last orchestrator host check invalid", "host", host)
 				ou.updateNodeCondition(host, api.NodeConditionLagged, core.ConditionUnknown)
 				ou.updateNodeCondition(host, api.NodeConditionReplicating, core.ConditionUnknown)
 				ou.updateNodeCondition(host, api.NodeConditionMaster, core.ConditionUnknown)

--- a/pkg/controller/orchestrator/orchestrator_reconcile_test.go
+++ b/pkg/controller/orchestrator/orchestrator_reconcile_test.go
@@ -121,6 +121,7 @@ var _ = Describe("Orchestrator reconciler", func() {
 				Slave_SQL_Running: false,
 				Slave_IO_Running:  false,
 				IsUpToDate:        true,
+				IsRecentlyChecked: true,
 				IsLastCheckValid:  true,
 			})
 		})
@@ -378,8 +379,9 @@ var _ = Describe("Orchestrator reconciler", func() {
 				Key:         orc.InstanceKey{Hostname: cluster.GetPodHostname(0)},
 				ReadOnly:    false, // mark node as master
 				// mark instance as uptodate
-				IsUpToDate:       true,
-				IsLastCheckValid: true,
+				IsUpToDate:        true,
+				IsRecentlyChecked: true,
+				IsLastCheckValid:  true,
 			})
 			orcClient.AddInstance(orc.Instance{
 				ClusterName: cluster.GetClusterAlias(),
@@ -390,8 +392,9 @@ var _ = Describe("Orchestrator reconciler", func() {
 				Slave_SQL_Running: true,
 				Slave_IO_Running:  true,
 				// mark instance as uptodate
-				IsUpToDate:       true,
-				IsLastCheckValid: true,
+				IsUpToDate:        true,
+				IsRecentlyChecked: true,
+				IsLastCheckValid:  true,
 			})
 
 			// update cluster nodes status
@@ -524,8 +527,9 @@ var _ = Describe("Orchestrator reconciler", func() {
 					Slave_SQL_Running: false,
 					Slave_IO_Running:  false,
 					// mark instance as uptodate
-					IsUpToDate:       true,
-					IsLastCheckValid: true,
+					IsUpToDate:        true,
+					IsRecentlyChecked: true,
+					IsLastCheckValid:  true,
 				})
 				insts, _ := orcClient.Cluster(cluster.GetClusterAlias())
 				master, _ := orcClient.Master(cluster.GetClusterAlias())
@@ -565,8 +569,9 @@ var _ = Describe("Orchestrator reconciler", func() {
 				Key:         orc.InstanceKey{Hostname: oldPodHostname(cluster, 0)},
 				ReadOnly:    false, // mark node as master
 				// mark instance as uptodate
-				IsUpToDate:       true,
-				IsLastCheckValid: true,
+				IsUpToDate:        true,
+				IsRecentlyChecked: true,
+				IsLastCheckValid:  true,
 			})
 			orcClient.AddInstance(orc.Instance{
 				ClusterName: cluster.GetClusterAlias(),

--- a/pkg/orchestrator/fake/client.go
+++ b/pkg/orchestrator/fake/client.go
@@ -207,8 +207,9 @@ func (o *OrcFakeClient) Discover(host string, port int) error {
 			Valid: false,
 			Int64: 0,
 		},
-		IsUpToDate:       true,
-		IsLastCheckValid: true,
+		IsUpToDate:        true,
+		IsRecentlyChecked: true,
+		IsLastCheckValid:  true,
 	})
 
 	return nil

--- a/test/e2e/cluster/cluster.go
+++ b/test/e2e/cluster/cluster.go
@@ -356,10 +356,11 @@ func testClusterRegistrationInOrchestrator(f *framework.Framework, cluster *api.
 				Hostname: f.GetPodHostname(cluster, 0),
 				Port:     3306,
 			}),
-			"GTIDMode":      Equal("ON"),
-			"IsUpToDate":    Equal(true),
-			"Binlog_format": Equal("ROW"),
-			"ReadOnly":      Equal(clusterReadOnly),
+			"GTIDMode":          Equal("ON"),
+			"IsUpToDate":        Equal(true),
+			"IsRecentlyChecked": Equal(true),
+			"Binlog_format":     Equal("ROW"),
+			"ReadOnly":          Equal(clusterReadOnly),
 		}), // master node
 	}
 	for i := 1; i < int(*cluster.Spec.Replicas); i++ {
@@ -368,10 +369,11 @@ func testClusterRegistrationInOrchestrator(f *framework.Framework, cluster *api.
 				Hostname: f.GetPodHostname(cluster, i),
 				Port:     3306,
 			}),
-			"GTIDMode":      Equal("ON"),
-			"IsUpToDate":    Equal(true),
-			"Binlog_format": Equal("ROW"),
-			"ReadOnly":      Equal(true),
+			"GTIDMode":          Equal("ON"),
+			"IsUpToDate":        Equal(true),
+			"IsRecentlyChecked": Equal(true),
+			"Binlog_format":     Equal("ROW"),
+			"ReadOnly":          Equal(true),
 		})) // slave node
 	}
 


### PR DESCRIPTION
Orchestrator does periodic health checking (discoveries) for every known
MySQL instance. This is driven in normal situation by [healthTick][ht]
firing by default every second. The health tick adds instances which have
`IsUpToDate == false` to the discovery queue. The queue is then consumed by
the discovery routine which updates the instances, but only those with
`IsUpToDate == false` ([second check][disc]).

So the instance healthcheck is driven by IsUpToDate property, and there
is a window where the instance is not actually up to date and is beeing
checked or will be soon scheduled to be.

At the same time the operator uses this property to identify instanaces
with outdated checks and configures them with unknown status. This race
leads to periodic switches of MySQL pods from services.

Property `IsRecentlyChecked` is the [five times][rece] the basic
`InstancePollSeconds` and should be more representative of Unknown state
for MySQL instance.

[ht]: https://github.com/openark/orchestrator/blob/master/go/logic/orchestrator.go#L342
[disc]: https://github.com/openark/orchestrator/blob/master/go/logic/orchestrator.go#L231
[oper]: https://github.com/presslabs/mysql-operator/blob/master/pkg/controller/orchestrator/orchestrator_reconcile.go#L211
[rece]: https://github.com/openark/orchestrator/blob/761be91299ce81abf6c9a3889a660549b8daef10/go/inst/instance_dao.go#L1153

Possibly related issue: #431

---
 - [ ] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.
