### PR TITLE
Parameterize backup scheduling constraints

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 ### Added
+ * Add `backupAffinity`, `backupNodeSelector`, `backupPriorityClassName`, `backupTolerations`
+   to `.Spec.PodSpec` to allow specifying custom scheduling constraints for backup jobs.
 ### Changed
 ### Removed
 ### Fixed

--- a/config/crds/mysql_v1alpha1_mysqlcluster.yaml
+++ b/config/crds/mysql_v1alpha1_mysqlcluster.yaml
@@ -121,6 +121,16 @@ spec:
                   type: object
                 annotations:
                   type: object
+                backupAffinity:
+                  type: object
+                backupNodeSelector:
+                  type: object
+                backupPriorityClassName:
+                  type: string
+                backupTolerations:
+                  items:
+                    type: object
+                  type: array
                 containers:
                   description: Containers allows for user to specify extra sidecar
                     containers to run along with mysql

--- a/examples/example-cluster.yaml
+++ b/examples/example-cluster.yaml
@@ -45,6 +45,10 @@ spec:
   #           topologyKey: "kubernetes.io/hostname"
   #           labelSelector:
   #             matchlabels: <cluster-labels>
+  #   backupAffinity: {}
+  #   backupNodeSelector: {}
+  #   backupPriorityClassName:
+  #   backupTolerations: []
   #   nodeSelector: {}
   #   resources:
   #     requests:

--- a/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
+++ b/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
@@ -179,6 +179,11 @@ type PodSpec struct {
 	Tolerations        []core.Toleration         `json:"tolerations,omitempty"`
 	ServiceAccountName string                    `json:"serviceAccountName,omitempty"`
 
+	BackupAffinity          *core.Affinity    `json:"backupAffinity,omitempty"`
+	BackupNodeSelector      map[string]string `json:"backupNodeSelector,omitempty"`
+	BackupPriorityClassName string            `json:"backupPriorityClassName,omitempty"`
+	BackupTolerations       []core.Toleration `json:"backupTolerations,omitempty"`
+
 	// Volumes allows adding extra volumes to the statefulset
 	// +optional
 	Volumes []core.Volume `json:"volumes,omitempty"`

--- a/pkg/apis/mysql/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/mysql/v1alpha1/zz_generated.deepcopy.go
@@ -439,6 +439,25 @@ func (in *PodSpec) DeepCopyInto(out *PodSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.BackupAffinity != nil {
+		in, out := &in.BackupAffinity, &out.BackupAffinity
+		*out = new(v1.Affinity)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.BackupNodeSelector != nil {
+		in, out := &in.BackupNodeSelector, &out.BackupNodeSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.BackupTolerations != nil {
+		in, out := &in.BackupTolerations, &out.BackupTolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Volumes != nil {
 		in, out := &in.Volumes, &out.Volumes
 		*out = make([]v1.Volume, len(*in))

--- a/pkg/controller/mysqlbackup/internal/syncer/job.go
+++ b/pkg/controller/mysqlbackup/internal/syncer/job.go
@@ -134,13 +134,28 @@ func (s *jobSyncer) ensurePodSpec(in core.PodSpec) core.PodSpec {
 		s.backup.GetBackupURL(s.cluster),
 	}
 
+	in.ImagePullSecrets = s.cluster.Spec.PodSpec.ImagePullSecrets
 	in.ServiceAccountName = s.cluster.Spec.PodSpec.ServiceAccountName
 
-	in.Affinity = s.cluster.Spec.PodSpec.Affinity
-	in.ImagePullSecrets = s.cluster.Spec.PodSpec.ImagePullSecrets
-	in.NodeSelector = s.cluster.Spec.PodSpec.NodeSelector
-	in.PriorityClassName = s.cluster.Spec.PodSpec.PriorityClassName
-	in.Tolerations = s.cluster.Spec.PodSpec.Tolerations
+	in.Affinity = s.cluster.Spec.PodSpec.BackupAffinity
+	if s.cluster.Spec.PodSpec.BackupAffinity == nil {
+		in.Affinity = s.cluster.Spec.PodSpec.Affinity
+	}
+
+	in.NodeSelector = s.cluster.Spec.PodSpec.BackupNodeSelector
+	if s.cluster.Spec.PodSpec.BackupNodeSelector == nil {
+		in.NodeSelector = s.cluster.Spec.PodSpec.NodeSelector
+	}
+
+	in.PriorityClassName = s.cluster.Spec.PodSpec.BackupPriorityClassName
+	if len(s.cluster.Spec.PodSpec.BackupPriorityClassName) == 0 {
+		in.PriorityClassName = s.cluster.Spec.PodSpec.PriorityClassName
+	}
+
+	in.Tolerations = s.cluster.Spec.PodSpec.BackupTolerations
+	if s.cluster.Spec.PodSpec.BackupTolerations == nil {
+		in.Tolerations = s.cluster.Spec.PodSpec.Tolerations
+	}
 
 	boolTrue := true
 	in.Containers[0].Env = []core.EnvVar{


### PR DESCRIPTION
Allows specifying custom scheduling constraints for backup jobs using the `backupAffinity`, `backupNodeSelector`, `backupPriorityClassName`, `backupTolerations` options in `spec.podSpec`. These four options should be enough to schedule the backup pod anywhere in the cluster. 

The default behaviour remains the same—if no backup-specific constraints are defined, the operator falls back to general `spec.podSpec` values.

Example that uses all options (a bit extreme and not very useful):

```yaml
---
apiVersion: mysql.presslabs.org/v1alpha1
kind: MysqlCluster
metadata:
  name: example
spec:
  # [...]
  podSpec:
    backupAffinity:
      nodeAffinity:
        requiredDuringSchedulingIgnoredDuringExecution:
          nodeSelectorTerms:
            - matchExpressions:
                - key: cloud.google.com/gke-preemptible
                  operator: In
                  values:
                    - "true"
    backupNodeSelector:
      failure-domain.beta.kubernetes.io/zone: us-east4-a
    backupPriorityClassName: mysql-backups
    backupTolerations:
      - key: preemptible
        operator: Equal
        value: "true"
        effect: NoExecute
  # [...]
```

Closes https://github.com/presslabs/mysql-operator/issues/540.

---
 - [x] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.