### PR TITLE
sidecar: add missing exec to entrypoint

### DIFF
--- a/hack/docker/sidecar-entrypoint.sh
+++ b/hack/docker/sidecar-entrypoint.sh
@@ -46,19 +46,19 @@ VERBOSE="--debug"
 case "$1" in
     clone-and-init)
         shift 1
-        $SIDECAR_BIN $VERBOSE clone-and-init "$@"
+        exec $SIDECAR_BIN $VERBOSE clone-and-init "$@"
         ;;
     config-and-serve)
         shift 1
-        $SIDECAR_BIN $VERBOSE run "$@"
+        exec $SIDECAR_BIN $VERBOSE run "$@"
         ;;
     take-backup-to)
         shift 1
-        $SIDECAR_BIN $VERBOSE take-backup-to "$@"
+        exec $SIDECAR_BIN $VERBOSE take-backup-to "$@"
         ;;
     schedule-backup)
         shift 1
-        $SIDECAR_BIN $VERBOSE schedule-backup "$@"
+        exec $SIDECAR_BIN $VERBOSE schedule-backup "$@"
         ;;
     *)
         echo "Usage: $0 {files-config|clone|config-and-serve}"


### PR DESCRIPTION
If sidecar container receives SIGTERM the bash will not properly
terminate the sidecar agent. Since the shell is not performing any
function after the sidecar is launched, just exec to sidecar.

This way the SIGTERM is received directly by sidecar terminating
imeddiately and the pod doesn't wait for grace termination period.

---
 - [ ] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.
