### PR TITLE
update sql_mode default

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
  * Set timeout of 15s on connection between the operator and Orchestrator
  * Bump controller-util dependency to 0.1.18 which fixes some updates on pod spec.
+ * Removed `NO_AUTO_VALUE_ON_ZERO` from `sql-mode` to be inline with MySQL default value
 ### Removed
 ### Fixed
 

--- a/pkg/controller/mysqlcluster/internal/syncer/config_map.go
+++ b/pkg/controller/mysqlcluster/internal/syncer/config_map.go
@@ -169,7 +169,7 @@ var mysqlMasterSlaveConfigs = map[string]string{
 	"max-allowed-packet": "16M",
 	"max-connect-errors": "1000000",
 	"sql-mode": "STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER," +
-		"NO_AUTO_VALUE_ON_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY",
+		"NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY",
 	"sysdate-is-now": "1",
 
 	// Binary logging


### PR DESCRIPTION
remove `NO_AUTO_VALUE_ON_ZERO` to be inline with mysql defaults

closes/fixes #543 

---
 - [x] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.
