### PR TITLE
pt-heartbeat: force UTC timezone

### DIFF
--- a/charts/mysql-operator/values.yaml
+++ b/charts/mysql-operator/values.yaml
@@ -146,7 +146,7 @@ orchestrator:
     RemoveTextFromHostnameDisplay: ":3306"
     DetectClusterAliasQuery: "SELECT CONCAT(SUBSTRING(@@hostname, 1, LENGTH(@@hostname) - 1 - LENGTH(SUBSTRING_INDEX(@@hostname,'-',-2))),'.',SUBSTRING_INDEX(@@report_host,'.',-1))"
     DetectInstanceAliasQuery: "SELECT @@hostname"
-    SlaveLagQuery: "SELECT TIMESTAMPDIFF(SECOND,ts,NOW()) as drift FROM sys_operator.heartbeat ORDER BY drift ASC LIMIT 1"
+    SlaveLagQuery: "SELECT TIMESTAMPDIFF(SECOND,ts,UTC_TIMESTAMP()) as drift FROM sys_operator.heartbeat ORDER BY drift ASC LIMIT 1"
 
     # Automated recovery (this is opt-in, so we need to set these)
     # Prevent recovery flip-flop, by disabling auto-recovery for 5 minutes per

--- a/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
+++ b/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
@@ -435,6 +435,7 @@ func (s *sfsSyncer) ensureContainersSpec() []core.Container {
 			"--create-table",
 			"--database", constants.OperatorDbName,
 			"--table", "heartbeat",
+			"--utc",
 			"--defaults-file", constants.ConfHeartBeatPath,
 			// it's important to exit when exceeding more than 20 failed attempts otherwise
 			// pt-heartbeat will run forever using old connection.


### PR DESCRIPTION
it's possible to create a MySQL Cluster instance with non default
timezone `default-time-zone: Somewhere\Something`. In which case
the Orchestrator will read up replication lag in adjusted time and assumes
the node have a replication lag (or comes from future).

Forcing UTC on both write and read endpoints to work correctly even
in this condition.

---

This can potentially lead to unwanted situation when operator image version doesn't correspond to the operator chart version. By default even now everything works in UTC, but there might be some corner cases in some setups. Might be useful to merge #559 first.

---
 - [ ] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.
