### PR TITLE
fix: release the chart with backupSechedule

### DIFF
--- a/charts/mysql-cluster/templates/cluster.yaml
+++ b/charts/mysql-cluster/templates/cluster.yaml
@@ -29,7 +29,7 @@ spec:
   {{- end }}
 
   {{- if .Values.backupSchedule }}
-  backupSchedule: {{ .Values.backupSchedule }}
+  backupSchedule: "{{ .Values.backupSchedule }}"
   backupRemoteDeletePolicy: {{ .Values.backupRemoteDeletePolicy }}
   backupURL: {{ required ".mysql.backupURL is missing" .Values.backupURL }}
   {{- end }}


### PR DESCRIPTION
cronjob schedule must be surrounded by quotes

closes/fixes #182

---
 - [ ] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.
