### PR TITLE
fix: Chart version must be immutable

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,9 +16,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
  * Remove use go module instead of dep
  * Update k8s client to `v0.18.2`
  * Update kubebuilder (to `v2.3.1`) along with controller-runtime (to `v0.6.0`) and controller-gen
+ * Update mysql-cluster helm chart to (`0.2.1`)
 ### Removed
 ### Fixed
-
+* Fix mysql-cluster helm chart - surrounding Values.backupSchedule by quotes
 
 ## [0.4.0] - 2020-06-17
 ### Added

--- a/charts/mysql-cluster/Chart.yaml
+++ b/charts/mysql-cluster/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for easy deployment of a MySQL cluster with MySQL operator.
 name: mysql-cluster
-version: 0.2.0
+version: 0.2.1


### PR DESCRIPTION
This is to patch the chart version according to changes of https://github.com/presslabs/mysql-operator/pull/570

closes/fixes #570

---
 - [x] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.
