### PR TITLE
feat: add initBucketURL and initBucketSecretName

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
    to `.Spec.PodSpec` to allow specifying custom scheduling constraints for backup jobs.
  * Add the ability to set the `imagePullSecrets` for the operator statefulset.
  * Add Google Drive via service account as backup option.
+ * Add `initBucketURL` and `initBucketSecretName` options to MysqlCluster chart. This bumps the chart version to `0.3.0`
 ### Changed
  * Set timeout of 15s on connection between the operator and Orchestrator
  * Bump controller-util dependency to 0.1.18 which fixes some updates on pod spec.

--- a/charts/mysql-cluster/Chart.yaml
+++ b/charts/mysql-cluster/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for easy deployment of a MySQL cluster with MySQL operator.
 name: mysql-cluster
-version: 0.2.0
+version: 0.3.0

--- a/charts/mysql-cluster/templates/cluster.yaml
+++ b/charts/mysql-cluster/templates/cluster.yaml
@@ -16,6 +16,13 @@ spec:
   secretName: {{ include "mysql-cluster.secretName" . }}
   {{- end }}
 
+  {{- if .Values.initBucketURL }}
+  initBucketURL: {{ .Values.initBucketURL }}
+  {{- end }}
+  {{- if .Values.initBucketSecretName }}
+  initBucketSecretName: {{ .Values.initBucketSecretName }}
+  {{- end }}
+
   {{- if .Values.backupSecretName }}
   backupSecretName: {{ .Values.backupSecretName }}
   {{- else if .Values.backupCredentials }}

--- a/charts/mysql-cluster/values.yaml
+++ b/charts/mysql-cluster/values.yaml
@@ -17,6 +17,9 @@ volumeSpec:
 
 serverIDOffset:
 
+initBucketURL:
+initBucketSecretName:
+
 backupSchedule:
 backupScheduleJobsHistoryLimit:
 backupURL:

--- a/docs/deploy-mysql-cluster.md
+++ b/docs/deploy-mysql-cluster.md
@@ -79,21 +79,23 @@ $ kubectl apply -f example-cluster.yaml
 
 Some important fields of `MySQLCluster` resource from `spec` are described in the following table:
 
-| Field Name                       | Description                                                                                 | Example                    | Default value           |
-| ---                              | ---                                                                                         | ---                        | ---                     |
-| `replicas`                       | The cluster replicas, how many nodes to deploy.                                             | 2                          | 1 (a single node)       |
-| `secretName`                     | The name of the credentials secret. Should be in the same namespace with the cluster.       | `my-secret`                | *is required*           |
-| `backupSchedule`                 | Represents the time and frequency of making cluster backups, in a cron format with seconds. | `0 0 0 * * *`              | ""                      |
-| `backupURL`                      | The bucket URL where to put the backup.                                                     | `gs://bucket/app`          | ""                      |
-| `backupSecretName`               | The name of the secret that contains credentials for connecting to the storage provider.    | `backups-secret`           | ""                      |
-| `backupScheduleJobsHistoryLimit` | The number of many backups to keep.                                                         | `10`                       | inf                     |
-| `image` | Specify a custom Docker image to be used for the MySQL server container. | `percona:5.7-centos` | nil |
-| `mysqlConf`                      | Key-value configs for MySQL that will be set in `my.cnf` under `mysqld` section.            | `max_allowed_packet: 128M` | {}                      |
-| `podSpec`                        | This allows to specify pod-related configs. (e.g. `imagePullSecrets`, `labels` )            |                            | {}                      |
-| `volumeSpec`                     | Specifications for PVC, HostPath or EmptyDir, used to store data.                           |                            | (a PVC with size = 1GB) |
-| `maxSlaveLatency`                | The allowed slave lag until it's removed from read service. (in seconds)                    | `30`                       | nil                     |
-| `queryLimits`                    | Parameters for pt-kill to ensure some query run limits. (e.g. idle time)                    | `idleTime: 60`             | nil                     |
-| `readOnly`                       | A Boolean value that sets the cluster in read-only state.                                   | `True`                     | False                   |
+| Field Name                       | Description                                                                                 | Example                            | Default value           |
+| ---                              | ---                                                                                         | ---                                | ---                     |
+| `replicas`                       | The cluster replicas, how many nodes to deploy.                                             | 2                                  | 1 (a single node)       |
+| `secretName`                     | The name of the credentials secret. Should be in the same namespace with the cluster.       | `my-secret`                        | *is required*           |
+| `initBucketURL`                  | The S3 URL that the cluster initialization backup is taken from                             | `s3://my-bucket/backup.xbackup.gz` | ""                      |
+| `initBucketSecretName`           | The secret that the S3 credentials for the initialization are read from                     | `backups-secret`                   | ""                      |
+| `backupSchedule`                 | Represents the time and frequency of making cluster backups, in a cron format with seconds. | `0 0 0 * * *`                      | ""                      |
+| `backupURL`                      | The bucket URL where to put the backup.                                                     | `gs://bucket/app`                  | ""                      |
+| `backupSecretName`               | The name of the secret that contains credentials for connecting to the storage provider.    | `backups-secret`                   | ""                      |
+| `backupScheduleJobsHistoryLimit` | The number of many backups to keep.                                                         | `10`                               | inf                     |
+| `image`                          | Specify a custom Docker image to be used for the MySQL server container.                    | `percona:5.7-centos`               | nil                     |
+| `mysqlConf`                      | Key-value configs for MySQL that will be set in `my.cnf` under `mysqld` section.            | `max_allowed_packet: 128M`         | {}                      |
+| `podSpec`                        | This allows to specify pod-related configs. (e.g. `imagePullSecrets`, `labels` )            |                                    | {}                      |
+| `volumeSpec`                     | Specifications for PVC, HostPath or EmptyDir, used to store data.                           |                                    | (a PVC with size = 1GB) |
+| `maxSlaveLatency`                | The allowed slave lag until it's removed from read service. (in seconds)                    | `30`                               | nil                     |
+| `queryLimits`                    | Parameters for pt-kill to ensure some query run limits. (e.g. idle time)                    | `idleTime: 60`                     | nil                     |
+| `readOnly`                       | A Boolean value that sets the cluster in read-only state.                                   | `True`                             | False                   |
 
 
 For more detailed information about cluster structure and configuration fields can be found in [godoc](https://godoc.org/github.com/presslabs/mysql-operator/pkg/apis/mysql/v1alpha1#MysqlClusterSpec).


### PR DESCRIPTION
This adds the possibility to use `initBucketURL` and `initBucketSecretName` with the MysqlCluster chart.

As this is a new feature, the chart version is bumped to `0.3.0`.

---
 - [x] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.
