### PR TITLE
fix:#363(file ./sys_operator/status.ibd is missing)

### DIFF
--- a/pkg/sidecar/appconf.go
+++ b/pkg/sidecar/appconf.go
@@ -191,6 +191,11 @@ func initFileQuery(cfg *Config, gtidPurged string) []byte {
 	// CSV engine for this table can't be used because we use REPLACE statement that requires PRIMARY KEY or
 	// UNIQUE KEY index
 	// nolint: gosec
+    if !strings.HasSuffix(cfg.Hostname, "-0") {
+        queries = append(queries, fmt.Sprintf("DROP TABLE IF EXISTS %s.%s",
+            constants.OperatorDbName, constants.OperatorStatusTableName))
+    }
+
 	queries = append(queries, fmt.Sprintf(
 		"CREATE TABLE IF NOT EXISTS %[1]s.%[2]s ("+
 			"  name varchar(64) PRIMARY KEY,"+


### PR DESCRIPTION
fixes #363
The "sys_operator.status" table of the slave node does not appear to be clean, although --tables-exclude is added to the backup. Delete "sys_operator.status" before starting from the slave node, and it's working fine now.
---
 - [ ] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.
