### PR TITLE
Parameterize compress/decompress commands

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
    it triggers a `graceful-master-takeover-auto` command in Orchestrator.
  * Add `mysqlLifecycle` to `.Spec.PodSpec` to allow overriding the default lifecycle hook
    for the `mysql` container.
+ * Add `backupCompressCommand` and `backupDecompressCommand` to allow using
+   different compressors/decompressors when backing up or restoring.
 ### Changed
  * Only add `binlog-space-limit` for `percona` image
  * Make user-defined InitContainer take the precedence

--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -52,7 +52,7 @@ RUN useradd -u 999 -r -g 999 -s /sbin/nologin \
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        apt-transport-https ca-certificates wget \
+        apt-transport-https ca-certificates pigz wget \
     && rm -rf /var/lib/apt/lists/*
 
 COPY hack/docker/percona.gpg /etc/apt/trusted.gpg.d/percona.gpg

--- a/config/crds/mysql.presslabs.org_mysqlclusters.yaml
+++ b/config/crds/mysql.presslabs.org_mysqlclusters.yaml
@@ -49,6 +49,16 @@ spec:
         spec:
           description: 'MysqlClusterSpec defines the desired state of MysqlCluster nolint: maligned'
           properties:
+            backupCompressCommand:
+              description: BackupCompressCommand is a command to use for compressing the backup.
+              items:
+                type: string
+              type: array
+            backupDecompressCommand:
+              description: BackupDecompressCommand is a command to use for decompressing the backup.
+              items:
+                type: string
+              type: array
             backupRemoteDeletePolicy:
               description: BackupRemoteDeletePolicy the deletion policy that specify how to treat the data from remote storage. By default it's used softDelete.
               type: string

--- a/examples/example-cluster.yaml
+++ b/examples/example-cluster.yaml
@@ -107,6 +107,16 @@ spec:
   ## Set cluster in read only
   # readOnly: false
 
+  ## Use `pigz` for parallel compression/decompression of backups
+  ## Or specify any arbitrary compress/decompress commands with args
+  # backupCompressCommand:
+  #   - pigz
+  #   - --stdout
+  #
+  # backupDecompressCommand:
+  #   - pigz
+  #   - --decompress
+
   ## Add metrics exporter extra arguments
   # metricsExporterExtraArgs:
   #   - --collect.info_schema.userstats

--- a/hack/development/Dockerfile.sidecar
+++ b/hack/development/Dockerfile.sidecar
@@ -38,7 +38,7 @@ RUN useradd -u 999 -r -g 999 -s /sbin/nologin \
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        apt-transport-https ca-certificates wget \
+        apt-transport-https ca-certificates pigz wget \
     && rm -rf /var/lib/apt/lists/*
 
 COPY hack/docker/percona.gpg /etc/apt/trusted.gpg.d/percona.gpg

--- a/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
+++ b/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
@@ -130,6 +130,14 @@ type MysqlClusterSpec struct {
 	// +optional
 	ServerIDOffset *int `json:"serverIDOffset,omitempty"`
 
+	// BackupCompressCommand is a command to use for compressing the backup.
+	// +optional
+	BackupCompressCommand []string `json:"backupCompressCommand,omitempty"`
+
+	// BackupDecompressCommand is a command to use for decompressing the backup.
+	// +optional
+	BackupDecompressCommand []string `json:"backupDecompressCommand,omitempty"`
+
 	// MetricsExporterExtraArgs is a list of extra command line arguments to pass to MySQL metrics exporter.
 	// See https://github.com/prometheus/mysqld_exporter for the list of available flags.
 	// +optional

--- a/pkg/apis/mysql/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/mysql/v1alpha1/zz_generated.deepcopy.go
@@ -252,6 +252,16 @@ func (in *MysqlClusterSpec) DeepCopyInto(out *MysqlClusterSpec) {
 		*out = new(int)
 		**out = **in
 	}
+	if in.BackupCompressCommand != nil {
+		in, out := &in.BackupCompressCommand, &out.BackupCompressCommand
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.BackupDecompressCommand != nil {
+		in, out := &in.BackupDecompressCommand, &out.BackupDecompressCommand
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.MetricsExporterExtraArgs != nil {
 		in, out := &in.MetricsExporterExtraArgs, &out.MetricsExporterExtraArgs
 		*out = make([]string, len(*in))

--- a/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
+++ b/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
@@ -234,6 +234,17 @@ func (s *sfsSyncer) getEnvFor(name string) []core.EnvVar {
 		})
 	}
 
+	hasBackupCompressCommand := len(s.cluster.Spec.BackupCompressCommand) > 0
+	hasBackupDecompressCommand := len(s.cluster.Spec.BackupDecompressCommand) > 0
+	if hasBackupCompressCommand && hasBackupDecompressCommand && isCloneAndInit(name) {
+		env = append(env, core.EnvVar{
+			Name:  "BACKUP_DECOMPRESS_COMMAND",
+			Value: strings.Join(s.cluster.Spec.BackupDecompressCommand, " "),
+		})
+	} else if hasBackupDecompressCommand {
+		log.Info("backupCompressCommand is not defined, falling back to gzip")
+	}
+
 	hasRcloneExtraArgs := len(s.cluster.Spec.RcloneExtraArgs) > 0
 	if hasRcloneExtraArgs && (isCloneAndInit(name) || isSidecar(name)) {
 		env = append(env, core.EnvVar{

--- a/pkg/sidecar/configs.go
+++ b/pkg/sidecar/configs.go
@@ -77,6 +77,12 @@ type Config struct {
 	// Offset for assigning MySQL Server ID
 	MyServerIDOffset int
 
+	// BackupCompressCommand is a command to use for compressing the backup.
+	BackupCompressCommand []string
+
+	// BackupDecompressCommand is a command to use for decompressing the backup.
+	BackupDecompressCommand []string
+
 	// RcloneExtraArgs is a list of extra command line arguments to pass to rclone.
 	RcloneExtraArgs []string
 
@@ -149,6 +155,22 @@ func (cfg *Config) IsFirstPodInSet() bool {
 // ShouldCloneFromBucket returns true if it's time to initialize from a bucket URL provided
 func (cfg *Config) ShouldCloneFromBucket() bool {
 	return !cfg.ExistsMySQLData && cfg.ServerID() == cfg.MyServerIDOffset && len(cfg.InitBucketURL) != 0
+}
+
+// BackupCompressCmd returns a command to use for compressing the backup.
+func (cfg *Config) BackupCompressCmd() []string {
+	if len(cfg.BackupCompressCommand) > 0 {
+		return cfg.BackupCompressCommand
+	}
+	return []string{"gzip", "--stdout"}
+}
+
+// BackupDecompressCmd returns a command to use for decompressing the backup.
+func (cfg *Config) BackupDecompressCmd() []string {
+	if len(cfg.BackupDecompressCommand) > 0 {
+		return cfg.BackupDecompressCommand
+	}
+	return []string{"gzip", "--decompress"}
 }
 
 // RcloneArgs returns a complete set of rclone arguments.
@@ -245,6 +267,8 @@ func NewConfig() *Config {
 
 		MyServerIDOffset: offset,
 
+		BackupCompressCommand:      strings.Fields(getEnvValue("BACKUP_COMPRESS_COMMAND")),
+		BackupDecompressCommand:    strings.Fields(getEnvValue("BACKUP_DECOMPRESS_COMMAND")),
 		RcloneExtraArgs:            strings.Fields(getEnvValue("RCLONE_EXTRA_ARGS")),
 		XbstreamExtraArgs:          strings.Fields(getEnvValue("XBSTREAM_EXTRA_ARGS")),
 		XtrabackupExtraArgs:        strings.Fields(getEnvValue("XTRABACKUP_EXTRA_ARGS")),


### PR DESCRIPTION
An improved version of https://github.com/presslabs/mysql-operator/pull/517.

Adds `backupCompressCommand` and `backupDecompressCommand` options that allow using any compressor/decompressor for backups. These options support arbitrary command line args as well.

Falls back to using `gzip` if the options are not provided.

```yaml
---
apiVersion: mysql.presslabs.org/v1alpha1
kind: MysqlCluster
metadata:
  name: example
spec:
  # [...]
  backupCompressCommand:
    - pigz # https://zlib.net/pigz/
    - --processes 8
    - --stdout
  backupDecompressCommand:
    - pigz
    - --decompress
  # [...]
```


---
 - [x] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.
