### PR TITLE
Add support for custom lifecycle hooks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
  * Add Google Drive via service account as backup option.
  * Add `initBucketURL` and `initBucketSecretName` options to MysqlCluster chart. This bumps the chart version to `0.3.0`
  * Add an example of how initContainers can be used to fix hostPath permissions.
+ * Add a lifecycle preStop hook for the `mysql` container. Before killing the master MySQL process,
+   it triggers a `graceful-master-takeover-auto` command in Orchestrator.
+ * Add `mysqlLifecycle` to `.Spec.PodSpec` to allow overriding the default lifecycle hook
+   for the `mysql` container.
 ### Changed
  * Only add `binlog-space-limit` for `percona` image
  * Make user-defined InitContainer take the precedence
@@ -28,7 +32,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 ### Fixed
  * Fix pod labels diff of map
- * Add a lifecycle preStop hook for the  `mysql` container. In `preStop` hook, before killing the master MySQL process, it triggers a `gracefaul-master-takeover-auto` from Orchestrator.
  * Fixed backup cleanup job bug (#577)
 
 

--- a/config/crds/mysql.presslabs.org_mysqlclusters.yaml
+++ b/config/crds/mysql.presslabs.org_mysqlclusters.yaml
@@ -2284,6 +2284,140 @@ spec:
                       description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                       type: object
                   type: object
+                mysqlLifecycle:
+                  description: Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.
+                  properties:
+                    postStart:
+                      description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host. Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                    preStop:
+                      description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: One and only one of the following should be specified. Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host. Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        tcpSocket:
+                          description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                      type: object
+                  type: object
                 mysqlOperatorSidecarResources:
                   description: MySQLOperatorSidecarResources allows you to specify resources for sidecar container used to take backups with xtrabackup
                   properties:

--- a/examples/example-cluster.yaml
+++ b/examples/example-cluster.yaml
@@ -49,6 +49,12 @@ spec:
   #   backupNodeSelector: {}
   #   backupPriorityClassName:
   #   backupTolerations: []
+  #   # Override the default preStop hook with a custom command/script
+  #   mysqlLifecycle:
+  #     preStop:
+  #       exec:
+  #         command:
+  #           - /scripts/demote-if-master
   #   nodeSelector: {}
   #   resources:
   #     requests:

--- a/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
+++ b/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
@@ -174,6 +174,7 @@ type PodSpec struct {
 	Annotations        map[string]string         `json:"annotations,omitempty"`
 	Resources          core.ResourceRequirements `json:"resources,omitempty"`
 	Affinity           *core.Affinity            `json:"affinity,omitempty"`
+	MysqlLifecycle     *core.Lifecycle           `json:"mysqlLifecycle,omitempty"`
 	NodeSelector       map[string]string         `json:"nodeSelector,omitempty"`
 	PriorityClassName  string                    `json:"priorityClassName,omitempty"`
 	Tolerations        []core.Toleration         `json:"tolerations,omitempty"`

--- a/pkg/apis/mysql/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/mysql/v1alpha1/zz_generated.deepcopy.go
@@ -406,6 +406,11 @@ func (in *PodSpec) DeepCopyInto(out *PodSpec) {
 		*out = new(v1.Affinity)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.MysqlLifecycle != nil {
+		in, out := &in.MysqlLifecycle, &out.MysqlLifecycle
+		*out = new(v1.Lifecycle)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.NodeSelector != nil {
 		in, out := &in.NodeSelector, &out.NodeSelector
 		*out = make(map[string]string, len(*in))

--- a/pkg/controller/mysqlcluster/internal/syncer/config_map.go
+++ b/pkg/controller/mysqlcluster/internal/syncer/config_map.go
@@ -52,8 +52,11 @@ func NewConfigMapSyncer(c client.Client, scheme *runtime.Scheme, cluster *mysqlc
 		}
 
 		cm.Data = map[string]string{
-			"my.cnf":      data,
-			shPreStopFile: buildBashPreStop(),
+			"my.cnf": data,
+		}
+
+		if cluster.Spec.PodSpec.MysqlLifecycle == nil {
+			cm.Data[shPreStopFile] = buildBashPreStop()
 		}
 
 		return nil

--- a/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
+++ b/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
@@ -371,12 +371,17 @@ func (s *sfsSyncer) ensureContainersSpec() []core.Container {
 		},
 	})
 
-	mysql.Lifecycle = &core.Lifecycle{
-		PreStop: &core.Handler{
-			Exec: &core.ExecAction{
-				Command: []string{"bash", fmt.Sprintf("%s/%s", ConfVolumeMountPath, shPreStopFile)},
+	if s.cluster.Spec.PodSpec.MysqlLifecycle != nil {
+		mysql.Lifecycle = s.cluster.Spec.PodSpec.MysqlLifecycle
+	} else {
+		mysql.Lifecycle = &core.Lifecycle{
+			PreStop: &core.Handler{
+				Exec: &core.ExecAction{
+					Command: []string{"bash", fmt.Sprintf("%s/%s", ConfVolumeMountPath, shPreStopFile)},
+				},
 			},
-		}}
+		}
+	}
 
 	// nolint: gosec
 	mysqlTestCmd := fmt.Sprintf(`mysql --defaults-file=%s -NB -e 'SELECT COUNT(*) FROM %s.%s WHERE name="configured" AND value="1"'`,


### PR DESCRIPTION
Makes it possible to override the default lifecycle hook added in https://github.com/presslabs/mysql-operator/pull/576. Doesn't change the default behaviour.

Our implementation of the hook is slightly different (although the general approach is similar), so we need this override. I'll share our version soon, need to generalize and optimize it a bit.

```yaml
---
apiVersion: mysql.presslabs.org/v1alpha1
kind: MysqlCluster
metadata:
  name: example
spec:
  # [...]
  podSpec:
    lifecycle:
      preStop:
        exec:
          command:
            - /scripts/custom-prestop-script
  # [...]
```

Re: https://github.com/presslabs/mysql-operator/issues/562

---
 - [x] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.