### PR TITLE
Stop building unused binaries in Dockerfiles

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -29,6 +29,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
  * Update rclone to `v1.53.1`
  * Update `Orchestrator` version from `v3.1.2` to `v3.2.3`
  * Set default MySQL server version to `5.7.31`
+ * Stop building unused binaries in Dockerfiles.
 ### Removed
 ### Fixed
  * Fix pod labels diff of map

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ###############################################################################
-#  Build the mysql-oerator related binaries
+#  Build the mysql-operator binary
 ###############################################################################
+
 FROM golang:1.13.14 as builder
 
 # Copy in the go src
@@ -11,8 +12,6 @@ COPY go.mod go.sum ./
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o mysql-operator github.com/presslabs/mysql-operator/cmd/mysql-operator
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o mysql-operator-sidecar github.com/presslabs/mysql-operator/cmd/mysql-operator-sidecar
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o orc-helper github.com/presslabs/mysql-operator/cmd/orc-helper
 
 ###############################################################################
 #  Docker image for operator

--- a/Dockerfile.orchestrator
+++ b/Dockerfile.orchestrator
@@ -1,5 +1,5 @@
 ###############################################################################
-#  Build the mysql-oerator related binaries
+#  Build the orc-helper binary
 ###############################################################################
 
 FROM golang:1.13.14 as builder
@@ -11,8 +11,6 @@ COPY cmd/    cmd/
 COPY go.mod go.sum ./
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o mysql-operator github.com/presslabs/mysql-operator/cmd/mysql-operator
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o mysql-operator-sidecar github.com/presslabs/mysql-operator/cmd/mysql-operator-sidecar
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o orc-helper github.com/presslabs/mysql-operator/cmd/orc-helper
 
 

--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -1,5 +1,5 @@
 ###############################################################################
-#  Build the mysql-oerator related binaries
+#  Build the mysql-operator-sidecar binary
 ###############################################################################
 
 FROM golang:1.13.14 as builder
@@ -11,9 +11,7 @@ COPY cmd/    cmd/
 COPY go.mod go.sum ./
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o mysql-operator github.com/presslabs/mysql-operator/cmd/mysql-operator
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o mysql-operator-sidecar github.com/presslabs/mysql-operator/cmd/mysql-operator-sidecar
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o orc-helper github.com/presslabs/mysql-operator/cmd/orc-helper
 
 
 ###############################################################################


### PR DESCRIPTION
Each of the three images uses only one corresponding binary. No need to build the other two. Speeds up the build process, especially for the Orchestrator image.

---
 - [x] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.