### PR TITLE
Fix Kubebuilder path in Makefile

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -33,6 +33,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
  * Fix pod labels diff of map
  * Fixed backup cleanup job bug (#577)
+ * Fix Kubebuilder path in Makefile.
 
 
 ## [0.4.0] - 2020-06-17

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ PATH := $(BINDIR):$(PATH)
 SHELL := env PATH=$(PATH) /bin/sh
 
 # check if kubebuilder is installed in local bin dir and set KUBEBUILDER_ASSETS
-ifeq 'yes' "$(shell test -f $(BINDIR)/kubebuilder && echo -n 'yes')"
-	KUBEBUILDER_ASSETS ?= $(BINDIR)
+ifneq ("$(wildcard $(BINDIR)/kubebuilder)", "")
+	export KUBEBUILDER_ASSETS ?= $(BINDIR)
 endif
 
 all: test build


### PR DESCRIPTION
Uses `make`'s [`wildcard`](https://www.gnu.org/software/make/manual/html_node/Wildcard-Function.html) function to check if `kubebuilder` executable exists. Shelling out and running `echo -n 'yes'` can be unpredictable in macOS (the result is `-n yes`, depending on a particular install). `wildcard` works the same everywhere.

`KUBEBUILDER_ASSETS` needs to be exported to be picked up by the child processes spawned by Ginkgo.

---
 - [x] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.
