### PR TITLE
Put graceful shutdown under feature flag

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,9 +14,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
  * Add `initBucketURL` and `initBucketSecretName` options to MysqlCluster chart. This bumps the chart version to `0.3.0`
  * Add an example of how initContainers can be used to fix hostPath permissions.
  * Add a lifecycle preStop hook for the `mysql` container. Before killing the master MySQL process,
-   it triggers a `graceful-master-takeover-auto` command in Orchestrator.
- * Add `mysqlLifecycle` to `.Spec.PodSpec` to allow overriding the default lifecycle hook
-   for the `mysql` container.
+   it triggers a `graceful-master-takeover-auto` command in Orchestrator. This is disabled by
+   default, to enable it set `gracefulShutdown.enabled=true` in chart values or set the controller
+   command argument `failover-before-shutdown` to `true`.
+ * Add `mysqlLifecycle` to `.Spec.PodSpec` to allow overriding the default lifecycle hook for the
+   `mysql` container.
  * Add `backupCompressCommand` and `backupDecompressCommand` to allow using
    different compressors/decompressors when backing up or restoring.
 ### Changed

--- a/charts/mysql-operator/templates/statefulset.yaml
+++ b/charts/mysql-operator/templates/statefulset.yaml
@@ -54,6 +54,11 @@ spec:
             {{- if .Values.watchNamespace }}
             - --namespace={{ .Values.watchNamespace }}
             {{- end }}
+            {{- if .Values.gracefulShutdown.enabled }}
+            - --failover-before-shutdown=true
+            {{- else }}
+            - --failover-before-shutdown=false
+            {{- end }}
             {{- range $arg := .Values.extraArgs }}
             - {{ $arg }}
             {{- end }}

--- a/charts/mysql-operator/values.yaml
+++ b/charts/mysql-operator/values.yaml
@@ -7,6 +7,11 @@ image: quay.io/presslabs/mysql-operator:latest
 sidecarImage: quay.io/presslabs/mysql-operator-sidecar:latest
 imagePullPolicy: IfNotPresent
 
+# Insert a pre-stop lifecycle hook and trigger a failover. NOTE: Use this when your cluster network
+# policy allows to connect across namespaces and the mysql node is able to connecto to operator pod
+gracefulShutdown:
+  enabled: false
+
 imagePullSecrets:
 # - name: "image-pull-secret"
 

--- a/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
+++ b/pkg/controller/mysqlcluster/internal/syncer/statefullset.go
@@ -382,9 +382,10 @@ func (s *sfsSyncer) ensureContainersSpec() []core.Container {
 		},
 	})
 
+	// set lifecycle hook on MySQL container
 	if s.cluster.Spec.PodSpec.MysqlLifecycle != nil {
 		mysql.Lifecycle = s.cluster.Spec.PodSpec.MysqlLifecycle
-	} else {
+	} else if s.opt.FailoverBeforeShutdownEnabled {
 		mysql.Lifecycle = &core.Lifecycle{
 			PreStop: &core.Handler{
 				Exec: &core.ExecAction{

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -72,6 +72,10 @@ type Options struct {
 
 	// OrchestratorConcurrentReconciles sets the orchestrator controller workers
 	OrchestratorConcurrentReconciles int32
+
+	// FailoverBeforeShutdownEnabled if enabled inserts a pre-stop lifecycle hook into pod
+	// to trigger a failover before shutdown
+	FailoverBeforeShutdownEnabled bool
 }
 
 type pullpolicy corev1.PullPolicy
@@ -108,6 +112,9 @@ const (
 	defaultLeaderElectionID        = "mysql-operator-leader-election"
 
 	defaultNamespace = ""
+
+	// TODO(next): make this true by default in next major release
+	defaultFailoverBeforeShutdownEnabled = false
 )
 
 var (
@@ -147,6 +154,9 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 
 	fs.Int32Var(&o.OrchestratorConcurrentReconciles, "orchestrator-concurrent-reconciles", 10,
 		"Set the number of workers for orchestrator reconciler.")
+
+	fs.BoolVar(&o.FailoverBeforeShutdownEnabled, "failover-before-shutdown", defaultFailoverBeforeShutdownEnabled,
+		"In pre-stop hook trigger a failover from Orchestrator")
 }
 
 var instance *Options
@@ -166,6 +176,8 @@ func GetOptions() *Options {
 			OrchestratorTopologyPassword: defaultOrchestratorTopologyPassword,
 
 			Namespace: defaultNamespace,
+
+			FailoverBeforeShutdownEnabled: defaultFailoverBeforeShutdownEnabled,
 		}
 	})
 


### PR DESCRIPTION
For the next release, we would like to keep the graceful shutdown feature under the feature flag and it will be disabled by default. This will be enabled in the next major release.

---
 - [x] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.
