### PR TITLE
Make the readOnly guarantee weeker and let the Orchestrator handle it

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -42,6 +42,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
  * Fix #632 lifeCycle preStop script is not copied to given directory.
  * Fix #637 mysqlbackup status is not updated correctly.
  * Fix #647 custom conf can't overwrite the default conf
+ * Fix #627 let Orchestrator do the failover
 
 ## [0.4.0] - 2020-06-17
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ vet:
 generate: manifests
 
 lint:
-	$(BINDIR)/golangci-lint run ./pkg/... ./cmd/...
+	$(BINDIR)/golangci-lint run --timeout 2m0s ./pkg/... ./cmd/...
 	hack/license-check
 
 .PHONY: chart

--- a/charts/mysql-operator/values.yaml
+++ b/charts/mysql-operator/values.yaml
@@ -167,12 +167,13 @@ orchestrator:
     RecoverMasterClusterFilters: ['.*']
     RecoverIntermediateMasterClusterFilters: ['.*']
     # `reset slave all` and `set read_only=0` on promoted master
-    ApplyMySQLPromotionAfterMasterFailover: false
-    MasterFailoverDetachReplicaMasterHost: true
+    ApplyMySQLPromotionAfterMasterFailover: true
     # https://github.com/github/orchestrator/blob/master/docs/configuration-recovery.md#promotion-actions
     # Safety! do not disable unless you know what you are doing
     FailMasterPromotionIfSQLThreadNotUpToDate: true
     DetachLostReplicasAfterMasterFailover: true
+    # set downtime on the failed master
+    MasterFailoverLostInstancesDowntimeMinutes: 10
 
     # orchestrator hooks called in the following order
     # for more information about template: https://github.com/github/orchestrator/blob/master/go/logic/topology_recovery.go#L256

--- a/config/crds/mysql.presslabs.org_mysqlclusters.yaml
+++ b/config/crds/mysql.presslabs.org_mysqlclusters.yaml
@@ -3373,7 +3373,7 @@ spec:
                 type: string
               type: array
             readOnly:
-              description: Makes the cluster READ ONLY. Set the master to writable or ReadOnly
+              description: Makes the cluster READ ONLY. This has not a strong guarantee, in case of a failover the cluster will be writable for at least a few seconds.
               type: boolean
             replicas:
               description: The number of pods. This updates replicas filed Defaults to 0

--- a/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
+++ b/pkg/apis/mysql/v1alpha1/mysqlcluster_types.go
@@ -122,7 +122,8 @@ type MysqlClusterSpec struct {
 	// +optional
 	QueryLimits *QueryLimits `json:"queryLimits,omitempty"`
 
-	// Makes the cluster READ ONLY. Set the master to writable or ReadOnly
+	// Makes the cluster READ ONLY. This has not a strong guarantee, in case of a failover the cluster will be writable
+	// for at least a few seconds.
 	// +optional
 	ReadOnly bool `json:"readOnly,omitempty"`
 

--- a/pkg/controller/orchestrator/orchestrator_controller.go
+++ b/pkg/controller/orchestrator/orchestrator_controller.go
@@ -147,7 +147,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 				// write all clusters to events chan to be processed
 				clusters.Range(func(key, value interface{}) bool {
 					events <- value.(event.GenericEvent)
-					log.V(1).Info("Schedule new cluster for reconciliation", "event", value)
+					log.V(1).Info("Schedule new cluster for reconciliation", "key", key)
 
 					return true
 				})

--- a/pkg/controller/orchestrator/orchestrator_reconcile_test.go
+++ b/pkg/controller/orchestrator/orchestrator_reconcile_test.go
@@ -382,6 +382,7 @@ var _ = Describe("Orchestrator reconciler", func() {
 				IsUpToDate:        true,
 				IsRecentlyChecked: true,
 				IsLastCheckValid:  true,
+				Uptime:            300,
 			})
 			orcClient.AddInstance(orc.Instance{
 				ClusterName: cluster.GetClusterAlias(),
@@ -395,6 +396,7 @@ var _ = Describe("Orchestrator reconciler", func() {
 				IsUpToDate:        true,
 				IsRecentlyChecked: true,
 				IsLastCheckValid:  true,
+				Uptime:            300,
 			})
 
 			// update cluster nodes status


### PR DESCRIPTION
closes/fixes #627

---
 - [x] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.
