### PR TITLE
Bump docker base image to use golang 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ###############################################################################
 #  Build the mysql-oerator related binaries
 ###############################################################################
-FROM golang:1.13.14 as builder
+FROM golang:1.16.0 as builder
 
 # Copy in the go src
 WORKDIR /go/src/github.com/presslabs/mysql-operator

--- a/Dockerfile.orchestrator
+++ b/Dockerfile.orchestrator
@@ -2,7 +2,7 @@
 #  Build the mysql-oerator related binaries
 ###############################################################################
 
-FROM golang:1.13.14 as builder
+FROM golang:1.16.0 as builder
 
 # Copy in the go src
 WORKDIR /go/src/github.com/presslabs/mysql-operator

--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -2,7 +2,7 @@
 #  Build the mysql-oerator related binaries
 ###############################################################################
 
-FROM golang:1.13.14 as builder
+FROM golang:1.16.0 as builder
 
 # Copy in the go src
 WORKDIR /go/src/github.com/presslabs/mysql-operator


### PR DESCRIPTION
closes/fixes #xyz

---
 - [ ] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.
