### PR TITLE
fix: run mysql on an empty volume

### DIFF
--- a/pkg/sidecar/util.go
+++ b/pkg/sidecar/util.go
@@ -63,8 +63,12 @@ func copyFile(src, dst string) error {
 // readPurgedGTID returns the GTID from xtrabackup_binlog_info file
 func readPurgedGTID() (string, error) {
 	file, err := os.Open(fmt.Sprintf("%s/xtrabackup_binlog_info", dataDir))
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		return "", err
+	}
+
+	if os.IsNotExist(err) {
+		return "", nil
 	}
 
 	defer func() {


### PR DESCRIPTION
closes/fixes #666

---
 - [x] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.
