### PR TITLE
Update example-cluster.yaml

### DIFF
--- a/examples/example-cluster.yaml
+++ b/examples/example-cluster.yaml
@@ -129,6 +129,7 @@ spec:
   #   - --retries-sleep=10s
   #   - --retries=10
   #   - --transfers=8
+  #   - --s3-force-path-style=false # when use Alibaba OSS
 
   ## Add extra arguments to xbstream
   # xbstreamExtraArgs:


### PR DESCRIPTION
When I backuping data to Alibaba OSS always error, after reading rcolne docs found this.

> Some providers (e.g. AWS, Aliyun OSS, Netease COS, or Tencent COS) require this set to false - rclone will do this automatically based on the provider setting.
>
> https://rclone.org/s3/#s3-force-path-style

So, I think add notice can help others.

