### PR TITLE
feat(cluster-chart): allow mysqlVersion and image override

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 ### Added
+ * Add `image` and `mysqlVersion` options to MysqlCluster chart. This bumps the chart version to `0.3.1`
  * Add `backupAffinity`, `backupNodeSelector`, `backupPriorityClassName`, `backupTolerations`
    to `.Spec.PodSpec` to allow specifying custom scheduling constraints for backup jobs.
  * Add the ability to set the `imagePullSecrets` for the operator statefulset.

--- a/charts/mysql-cluster/Chart.yaml
+++ b/charts/mysql-cluster/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for easy deployment of a MySQL cluster with MySQL operator.
 name: mysql-cluster
-version: 0.3.0
+version: 0.3.1

--- a/charts/mysql-cluster/templates/cluster.yaml
+++ b/charts/mysql-cluster/templates/cluster.yaml
@@ -16,6 +16,14 @@ spec:
   secretName: {{ include "mysql-cluster.secretName" . }}
   {{- end }}
 
+  {{- if .Values.image }}
+  image: {{ .Values.image }}
+  {{- end }}
+
+  {{- if .Values.mysqlVersion }}
+  mysqlVersion: {{ .Values.mysqlVersion | quote }}
+  {{- end }}
+
   {{- if .Values.initBucketURL }}
   initBucketURL: {{ .Values.initBucketURL }}
   {{- end }}

--- a/charts/mysql-cluster/values.yaml
+++ b/charts/mysql-cluster/values.yaml
@@ -5,6 +5,11 @@
 ## The cluster number of nodes
 replicas: 1
 
+## For setting custom docker image or specifying mysql version
+## the image field has priority over mysqlVersion.
+# image: percona:5.7
+# mysqlVersion: "5.7"
+
 ## MySQL connect credentials, those credentials will be provisioned in the cluster
 rootPassword: ""
 appUser: ""


### PR DESCRIPTION
backwards compatible change that enables specifying the cluster `mysqlVersion`. follows the convention established in the [examples folder](https://github.com/presslabs/mysql-operator/blob/573f14bd883354329865038a6507d94a2fd9218b/examples/example-cluster.yaml#L9-L12)
---
 - [x] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.

test using this values.yaml
```yaml
mysqlVersion: "8.0"
```  
results in
```
    Environment:
...
      MY_MYSQL_VERSION:  8.0.20
```   