### PR TITLE
Update rbac.authorization.k8s.io version in clusterrolebinding.yaml

### DIFF
--- a/charts/mysql-operator/templates/clusterrolebinding.yaml
+++ b/charts/mysql-operator/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "mysql-operator.fullname" . }}


### PR DESCRIPTION
Update rbac.authorization.k8s.io/v1beta1 to rbac.authorization.k8s.io/v1

```
Warning: rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+
```

closes/fixes #xyz

---
 - [x] I've made sure the [Changelog.md](https://github.com/presslabs/mysql-operator/blob/master/Changelog.md) will remain up-to-date after this PR is merged.
