### PR TITLE
mysqlVersion requires a quote

### DIFF
--- a/examples/example-cluster.yaml
+++ b/examples/example-cluster.yaml
@@ -9,7 +9,7 @@ spec:
   ## For setting custom docker image or specifying mysql version
   ## the image field has priority over mysqlVersion.
   # image: percona:5.7
-  # mysqlVersion: 5.7
+  # mysqlVersion: "5.7"
 
   # initBucketURL: gs://bucket_name/backup.xtrabackup.gz
   # initBucketSecretName:


### PR DESCRIPTION
This PR is because of this error.

```
E0706 04:12:20.984838       1 reflector.go:134] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:126: Failed to list *v1alpha1.MysqlCluster: v1alpha1.MysqlClusterList.Items: []v1alpha1.MysqlCluster: v1alpha1.MysqlCluster.Spec: v1alpha1.MysqlClusterSpec.MysqlVersion: ReadString: expects " or n, but found 5, error found in #10 byte of ...|Version":5.7,"podSpe|..., bigger context ...|-45e4-8136-6d21d33cf0a4"},"spec":{"mysqlVersion":5.7,"podSpec":{"metricsExporterResources":{},"mysql|...
```