### PR TITLE
Revert "fix: unable to open database file"

### DIFF
--- a/deploy/charts/mysql-operator/templates/statefulset.yaml
+++ b/deploy/charts/mysql-operator/templates/statefulset.yaml
@@ -93,6 +93,8 @@ spec:
               secretRef:
                 name: {{ template "mysql-operator.orc-secret-name" . }}
           volumeMounts:
+            - name: data
+              mountPath: /var/lib/orchestrator/
             - name: config
               mountPath: /usr/local/share/orchestrator/templates/
           livenessProbe:
@@ -118,13 +120,6 @@ spec:
         - name: data
           emptyDir: {}
         {{- end }}
-      initContainers:
-        - name: init-mount
-          image: busybox:1.34.0
-          command: ['sh', '-c', "chown -R 777:777 /var/lib/orchestrator"]
-          volumeMounts:
-            - name: data
-              mountPath: /var/lib/orchestrator/
 
       # security context to mount corectly the volume for orc
       securityContext:


### PR DESCRIPTION
I'm reverting bitpoke/mysql-operator#729 as it basically removes the persistent storage for orchestrator. I'm preparing a PR that should fix #615 by using `PodSecurityContext`.