### PR TITLE
fix orchestrator startup crash in DualStack cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 ### Fixed
 * Avoid set read_only conflict when graceful takeover
+* Fix orchestrator startup crash in DualStack cluster
 
 ## [0.6.3] - 2023-05-22
 

--- a/deploy/charts/mysql-operator/templates/orchestrator-config.yaml
+++ b/deploy/charts/mysql-operator/templates/orchestrator-config.yaml
@@ -8,7 +8,7 @@
 {{- $_ := set $conf "RaftEnabled" true }}
 {{- $_ := set $conf "RaftDataDir" "/var/lib/orchestrator" }}
 {{- $_ := set $conf "RaftAdvertise" "{{ .Env.HOSTNAME }}-orc-svc" }}
-{{- $_ := set $conf "RaftBind" "{{ .Env.HOSTNAME }}"}}
+{{- $_ := set $conf "RaftBind" "{{ .Env.POD_IP }}"}}
 {{- $_ := set $conf "HTTPAdvertise" "http://{{ .Env.HOSTNAME }}-orc-svc:80" }}
 {{- if eq 1 $replicas -}}
 {{- $_ := set $conf "RaftNodes" (list) }}

--- a/deploy/charts/mysql-operator/values.yaml
+++ b/deploy/charts/mysql-operator/values.yaml
@@ -212,7 +212,7 @@ orchestrator:
   #   - SQLite3DataFile /var/lib/orchestrator/orc.db
   #   - RaftEnabled true
   #   - RaftDataDir /var/lib/orchestrator
-  #   - RaftBind $HOSTNAME
+  #   - RaftBind $POD_IP
   #   - RaftNodes The statefullset members
   config:
     Debug: false


### PR DESCRIPTION
In a cluster where `.Env.HOSTNAME` resolves to an IPv6 address, the orchestrator fails to start due to a syntax error in the raft bind address. This was reported here: https://github.com/bitpoke/mysql-operator/issues/929

This commit fixes this, at least for DualStack clusters, by using `.Env.POD_IP` instead, which is defined as

```yaml
- name: POD_IP
  valueFrom:
    fieldRef:
      apiVersion: v1
      fieldPath: status.podIP
```

and thus typically points to an IPv4 address in DualStack clusters. For a general fix, the orchestrator code itself probably needs to be modified to correctly handle the bind hostname.

---
 - [x] I've made sure the [CHANGELOG.md](https://github.com/presslabs/mysql-operator/blob/master/CHANGELOG.md) will remain up-to-date after this PR is merged.